### PR TITLE
:construction_worker: CI: pytest と CLI smoke を GitHub Actions で自動実行

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,11 @@ jobs:
   test:
     name: pytest (py${{ matrix.python-version }})
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11", "3.12"]
+        python-version: ["3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4
 
@@ -35,8 +36,13 @@ jobs:
         run: uv run python -m pytest tests/ -v
 
   cli-smoke:
-    name: zoo --help (import smoke)
+    name: zoo --help (py${{ matrix.python-version }})
     runs-on: ubuntu-latest
+    timeout-minutes: 5
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.13"]
     steps:
       - uses: actions/checkout@v4
 
@@ -46,7 +52,7 @@ jobs:
           enable-cache: true
 
       - name: Set up Python
-        run: uv python install 3.12
+        run: uv python install ${{ matrix.python-version }}
 
       - name: Sync dependencies
         run: uv sync --extra dev

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,59 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: pytest (py${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        run: uv python install ${{ matrix.python-version }}
+
+      - name: Sync dependencies
+        run: uv sync --extra dev
+
+      - name: Run pytest
+        run: uv run python -m pytest tests/ -v
+
+  cli-smoke:
+    name: zoo --help (import smoke)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Sync dependencies
+        run: uv sync --extra dev
+
+      - name: Verify zoo CLI loads
+        run: |
+          uv run zoo --help
+          uv run zoo run --help
+          uv run zoo logs --help
+          uv run zoo test --help

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 # Agent Zoo
 
+[![CI](https://github.com/ymdarake/agent-zoo/actions/workflows/ci.yml/badge.svg)](https://github.com/ymdarake/agent-zoo/actions/workflows/ci.yml)
+
 AIコーディングエージェントを安全に自律実行するためのセキュリティハーネス。
 
 mitmproxyペイロード検査 + TOMLポリシー制御。エージェント非依存で動作。


### PR DESCRIPTION
## Summary
- `.github/workflows/ci.yml` を新設して PR 時に pytest を自動実行
- Python 3.11 / 3.12 マトリクス
- `zoo --help` / 主要サブコマンドの `--help` をスモークで叩いて CLI が壊れていないか確認
- README に CI バッジ追加

## 実装メモ
- astral-sh/setup-uv@v3 + キャッシュ有効化
- Docker 依存の smoke test は CI で走らせない（コスト・安定性の観点）
- ruff / mypy は今回はスコープ外

## Base
PR #4 (feat/zoo-cli) を base にしています。#4 が main にマージされ次第 rebase します。

## Closes
- Closes #5

## Test plan
- [ ] Actions タブで `CI / pytest (py3.11)` / `pytest (py3.12)` / `zoo --help` が PASS
- [ ] バッジがリポジトリトップで緑になる