### PR TITLE
:sparkles: Python API として import 可能にする

### DIFF
--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -1,0 +1,65 @@
+# Python API
+
+`zoo` は CLI だけでなく Python ライブラリとしても使えます。自動化・カスタム統合・
+notebook からの実験などに利用できます。
+
+## インストール
+
+```bash
+uv tool install .        # グローバルコマンドも入る
+# または
+pip install .
+```
+
+## クイックスタート
+
+```python
+import zoo
+
+# 対話モードを非同期で起動（TTY 必須）
+exit_code = zoo.run(agent="claude", workspace="/path/to/my-project")
+
+# ワンショット自律実行
+import os
+os.environ["CLAUDE_CODE_OAUTH_TOKEN"] = "..."
+exit_code = zoo.task(prompt="テストを追加して", agent="claude")
+
+# 起動のみ（exec しない）
+zoo.up(agent="claude", workspace="/path/to/project")
+# ... 何か処理 ...
+zoo.down()
+
+# ログ操作
+if zoo.logs_clear():
+    print("logs cleared")
+
+candidates = zoo.logs_candidates()
+for c in candidates:
+    print(f"{c['type']}: {c['value']}")
+```
+
+## API 一覧
+
+| 関数 | 戻り値 | 備考 |
+|---|---|---|
+| `zoo.run(*, agent, workspace, dangerous)` | `int` (exit code) | TTY attach |
+| `zoo.task(*, prompt, agent, workspace)` | `int` | 環境変数による認証必須 |
+| `zoo.up(*, agent, workspace, dashboard_only, strict)` | `None` | |
+| `zoo.down()` | `None` | strict プロファイルも対象 |
+| `zoo.reload_policy()` | `None` | policy.toml 反映 |
+| `zoo.build(*, agent)` | `None` | |
+| `zoo.certs()` | `None` | 存在すれば何もしない |
+| `zoo.host_start()` / `zoo.host_stop()` | `int` | |
+| `zoo.logs_clear()` | `bool` | 削除した場合 True |
+| `zoo.logs_candidates()` | `list[dict]` | policy_candidate.toml をパース |
+| `zoo.logs_analyze()` / `summarize()` / `alerts()` | `int` | ホスト側 `claude` CLI 必須 |
+| `zoo.test_unit()` / `zoo.test_smoke(*, agent)` | `int` | |
+
+## 設計メモ
+
+- `zoo.api` に純粋な関数 API を置き、`zoo.cli` は typer ラッパー
+- typer / rich 依存は CLI 層のみ。API 層は stdlib + `tomllib`
+- `zoo` パッケージは `docker-compose.yml` と `policy.toml` のあるディレクトリを
+  CWD から親方向に探索（`zoo.runner.repo_root()`）。agent-zoo リポジトリを
+  clone した場所で呼び出してください
+- 長時間実行されるコマンド（`run`, `task`）は subprocess を TTY に attach します

--- a/src/zoo/__init__.py
+++ b/src/zoo/__init__.py
@@ -1,1 +1,41 @@
+"""Agent Zoo — AIコーディングエージェント用セキュリティハーネス."""
+from .api import (
+    build,
+    certs,
+    down,
+    host_start,
+    host_stop,
+    logs_alerts,
+    logs_analyze,
+    logs_candidates,
+    logs_clear,
+    logs_summarize,
+    reload_policy,
+    run,
+    task,
+    test_smoke,
+    test_unit,
+    up,
+)
+
 __version__ = "0.1.0"
+
+__all__ = [
+    "__version__",
+    "build",
+    "certs",
+    "down",
+    "host_start",
+    "host_stop",
+    "logs_alerts",
+    "logs_analyze",
+    "logs_candidates",
+    "logs_clear",
+    "logs_summarize",
+    "reload_policy",
+    "run",
+    "task",
+    "test_smoke",
+    "test_unit",
+    "up",
+]

--- a/src/zoo/api.py
+++ b/src/zoo/api.py
@@ -213,16 +213,17 @@ def _pipe_to_claude(sqlite_query: str, prompt: str, *, extra_context: str = "") 
         ["sqlite3", str(db_path), "-json", sqlite_query],
         stdout=subprocess.PIPE,
     )
-    assert sqlite.stdout is not None
-    if extra_context:
-        data = sqlite.stdout.read()
-        sqlite.wait()
-        input_bytes = (extra_context + "\n" + data.decode()).encode()
-        claude = subprocess.Popen(["claude", "-p", prompt], stdin=subprocess.PIPE)
-        assert claude.stdin is not None
-        claude.stdin.write(input_bytes)
-        claude.stdin.close()
+    try:
+        if extra_context:
+            data = sqlite.stdout.read()  # type: ignore[union-attr]
+            sqlite.wait()
+            input_bytes = (extra_context + "\n" + data.decode()).encode()
+            claude = subprocess.Popen(["claude", "-p", prompt], stdin=subprocess.PIPE)
+            claude.stdin.write(input_bytes)  # type: ignore[union-attr]
+            claude.stdin.close()
+            return claude.wait()
+        claude = subprocess.Popen(["claude", "-p", prompt], stdin=sqlite.stdout)
+        sqlite.stdout.close()  # type: ignore[union-attr]
         return claude.wait()
-    claude = subprocess.Popen(["claude", "-p", prompt], stdin=sqlite.stdout)
-    sqlite.stdout.close()
-    return claude.wait()
+    finally:
+        sqlite.wait()

--- a/src/zoo/api.py
+++ b/src/zoo/api.py
@@ -1,0 +1,228 @@
+"""Public Python API for Agent Zoo.
+
+Import as:
+    from zoo import run, task, up, down, logs_candidates, ...
+
+All functions are plain Python — no typer/rich dependency — so you can use them
+from notebooks, other scripts, or custom tooling.
+
+Interactive commands (``run``, ``task``, ``host_start``, ``test_unit``,
+``test_smoke``) attach the current process stdio and return a subprocess-style
+exit code. Non-interactive commands raise on failure or return structured data.
+"""
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Any
+
+from . import runner
+
+
+def run(
+    *,
+    agent: str = "claude",
+    workspace: str | Path | None = None,
+    dangerous: bool = False,
+) -> int:
+    """Launch an interactive agent session.
+
+    Returns the agent process exit code.
+    """
+    cfg = runner.resolve_agent(agent)
+    runner.compose_up([cfg.name, "dashboard"], workspace=_as_str(workspace))
+    cmd = cfg.run_dangerous_cmd if dangerous else cfg.run_cmd
+    return runner.run_interactive(cmd)
+
+
+def task(
+    *,
+    prompt: str,
+    agent: str = "claude",
+    workspace: str | Path | None = None,
+) -> int:
+    """Run a one-shot autonomous task. Auth via the agent's required env var.
+
+    Returns the agent process exit code.
+    """
+    cfg = runner.resolve_agent(agent)
+    runner.require_env(
+        cfg.required_env,
+        hint=f"Set {cfg.required_env} before calling task().",
+    )
+    runner.compose_up([cfg.name, "dashboard"], workspace=_as_str(workspace))
+    cmd = [arg.replace("{prompt}", prompt) for arg in cfg.task_cmd_template]
+    return runner.run_interactive(cmd)
+
+
+def up(
+    *,
+    agent: str = "claude",
+    workspace: str | Path | None = None,
+    dashboard_only: bool = False,
+    strict: bool = False,
+) -> None:
+    """Start containers without attaching (no exec)."""
+    if dashboard_only:
+        services = ["proxy", "dashboard"]
+    else:
+        cfg = runner.resolve_agent(agent)
+        services = [cfg.name, "dashboard"]
+    runner.compose_up(services, workspace=_as_str(workspace), strict=strict)
+
+
+def down() -> None:
+    """Stop containers (includes strict profile if present)."""
+    env = runner.compose_env()
+    strict_cmd = [
+        "docker", "compose", "--profile", "strict",
+        "-f", "docker-compose.yml", "-f", "docker-compose.strict.yml",
+        "down",
+    ]
+    result = subprocess.run(strict_cmd, env=env, cwd=runner.repo_root())
+    if result.returncode != 0:
+        runner.run(["docker", "compose", "down"], env=env, check=False)
+
+
+def reload_policy() -> None:
+    """Reload policy.toml by restarting proxy + dashboard (clears addon cache)."""
+    cache = runner.repo_root() / "addons" / "__pycache__"
+    if cache.exists():
+        shutil.rmtree(cache)
+    runner.run(
+        ["docker", "compose", "restart", "proxy", "dashboard"],
+        env=runner.compose_env(),
+    )
+
+
+def build(*, agent: str = "claude") -> None:
+    """Build docker images for the given agent + dashboard."""
+    cfg = runner.resolve_agent(agent)
+    runner.ensure_certs()
+    runner.run(
+        ["docker", "compose", "build", cfg.name, "dashboard"],
+        env=runner.compose_env(),
+    )
+
+
+def certs() -> None:
+    """Generate the mitmproxy CA certificate if missing."""
+    runner.ensure_certs()
+
+
+def host_start() -> int:
+    """Start host-mode mitmproxy via host/setup.sh."""
+    return runner.run_interactive(["./host/setup.sh"])
+
+
+def host_stop() -> int:
+    """Stop host-mode mitmproxy via host/stop.sh."""
+    return runner.run_interactive(["./host/stop.sh"])
+
+
+def logs_clear() -> bool:
+    """Delete harness.db (and WAL/SHM). Returns True if anything was removed."""
+    db = runner.repo_root() / "data" / "harness.db"
+    if not db.exists():
+        return False
+    for name in ("harness.db", "harness.db-wal", "harness.db-shm"):
+        (runner.repo_root() / "data" / name).unlink(missing_ok=True)
+    return True
+
+
+def logs_candidates() -> list[dict[str, Any]]:
+    """Parsed whitelist candidates from ``policy_candidate.toml``."""
+    import tomllib
+
+    candidate_file = runner.repo_root() / "policy_candidate.toml"
+    if not candidate_file.exists():
+        return []
+    data = tomllib.loads(candidate_file.read_text())
+    return list(data.get("candidates", []))
+
+
+def logs_analyze() -> int:
+    """Pipe block-log summary + policy.toml into ``claude -p`` for analysis."""
+    query = (
+        "SELECT host, COUNT(*) as n, GROUP_CONCAT(DISTINCT status) as statuses "
+        "FROM requests WHERE status IN ('BLOCKED','RATE_LIMITED','PAYLOAD_BLOCKED') "
+        "GROUP BY host ORDER BY n DESC"
+    )
+    policy = (runner.repo_root() / "policy.toml").read_text()
+    context = f"=== ブロックログ ===\n\n=== 現在のpolicy.toml ===\n{policy}"
+    return _pipe_to_claude(
+        query,
+        "ブロックログとpolicy.tomlを比較して改善案をTOML形式で提案して。"
+        "許可すべきドメインとその理由、危険なドメインとその理由を分けて。",
+        extra_context=context,
+    )
+
+
+def logs_summarize() -> int:
+    """Pipe recent tool_use log into ``claude -p`` for policy suggestion."""
+    query = (
+        "SELECT tool_name, input, input_size, ts "
+        "FROM tool_uses ORDER BY ts DESC LIMIT 100"
+    )
+    return _pipe_to_claude(
+        query,
+        "このtool_use履歴からホストモード用settings.jsonの最小権限設定を提案して",
+    )
+
+
+def logs_alerts() -> int:
+    """Pipe recent alerts into ``claude -p`` for review."""
+    query = "SELECT * FROM alerts ORDER BY ts DESC LIMIT 50"
+    return _pipe_to_claude(query, "セキュリティ上の懸念があるパターンを報告して")
+
+
+def test_unit() -> int:
+    """Run the project's pytest suite."""
+    return runner.run_interactive(
+        ["uv", "run", "python", "-m", "pytest", "tests/", "-v"],
+    )
+
+
+def test_smoke(*, agent: str = "claude") -> int:
+    """Run the Docker smoke test (delegates to Makefile)."""
+    env = runner.compose_env()
+    env["AGENT"] = agent
+    return subprocess.call(
+        ["make", "test", f"AGENT={agent}"],
+        env=env,
+        cwd=runner.repo_root(),
+    )
+
+
+# --- internal helpers --------------------------------------------------------
+
+def _as_str(value: str | Path | None) -> str | None:
+    return str(value) if value is not None else None
+
+
+def _pipe_to_claude(sqlite_query: str, prompt: str, *, extra_context: str = "") -> int:
+    """Run ``sqlite3 ... | claude -p PROMPT``. Returns the claude exit code."""
+    db_path = runner.repo_root() / "data" / "harness.db"
+    if not db_path.exists():
+        raise FileNotFoundError(
+            "data/harness.db が見つかりません。先にエージェントを実行してください。"
+        )
+    sqlite = subprocess.Popen(
+        ["sqlite3", str(db_path), "-json", sqlite_query],
+        stdout=subprocess.PIPE,
+    )
+    assert sqlite.stdout is not None
+    if extra_context:
+        data = sqlite.stdout.read()
+        sqlite.wait()
+        input_bytes = (extra_context + "\n" + data.decode()).encode()
+        claude = subprocess.Popen(["claude", "-p", prompt], stdin=subprocess.PIPE)
+        assert claude.stdin is not None
+        claude.stdin.write(input_bytes)
+        claude.stdin.close()
+        return claude.wait()
+    claude = subprocess.Popen(["claude", "-p", prompt], stdin=sqlite.stdout)
+    sqlite.stdout.close()
+    return claude.wait()

--- a/src/zoo/cli.py
+++ b/src/zoo/cli.py
@@ -1,29 +1,13 @@
-"""Agent Zoo CLI — `zoo` command.
-
-Subcommand map:
-    zoo run            対話モード起動
-    zoo task           自律実行（非対話）
-    zoo up             サービスだけ起動
-    zoo down           サービス停止
-    zoo reload         policy.toml を反映
-    zoo build          Dockerイメージビルド
-    zoo certs          CA証明書生成
-    zoo host start|stop   ホストモード
-    zoo logs ...       ログ操作（clear/analyze/summarize/alerts/candidates）
-    zoo test unit|smoke   テスト
-"""
+"""Agent Zoo CLI — `zoo` command. Thin typer wrapper around :mod:`zoo.api`."""
 from __future__ import annotations
 
 import os
-import shutil
-import subprocess
 import sys
 from typing import Optional
 
 import typer
 
-from . import runner
-from .runner import compose_env, compose_up, ensure_certs, repo_root, require_env, resolve_agent, run
+from . import api
 
 app = typer.Typer(
     help="Agent Zoo — AIコーディングエージェント用セキュリティハーネス",
@@ -44,16 +28,13 @@ def run_cmd(
     dangerous: bool = typer.Option(False, "--dangerous", help="承認なし（箱庭モード）"),
 ) -> None:
     """対話モードでエージェントを起動。"""
-    cfg = resolve_agent(agent)
-    compose_up([cfg.name, "dashboard"], workspace=workspace)
     ws = workspace or os.environ.get("WORKSPACE", "./workspace")
     if dangerous:
-        typer.echo(f"箱庭モード: 承認なし自律実行（ネットワーク隔離で保護） (AGENT={cfg.name}, WORKSPACE={ws})")
-        cmd = cfg.run_dangerous_cmd
+        typer.echo(f"箱庭モード: 承認なし自律実行（ネットワーク隔離で保護） (AGENT={agent}, WORKSPACE={ws})")
     else:
-        typer.echo(f"{cfg.run_hint} (AGENT={cfg.name}, WORKSPACE={ws})")
-        cmd = cfg.run_cmd
-    sys.exit(runner.run_interactive(cmd))
+        from .runner import resolve_agent
+        typer.echo(f"{resolve_agent(agent).run_hint} (AGENT={agent}, WORKSPACE={ws})")
+    sys.exit(api.run(agent=agent, workspace=workspace, dangerous=dangerous))
 
 
 @app.command()
@@ -63,14 +44,7 @@ def task(
     workspace: Optional[str] = WorkspaceOpt,
 ) -> None:
     """自律実行（非対話）。認証は環境変数で渡す。"""
-    cfg = resolve_agent(agent)
-    require_env(
-        cfg.required_env,
-        hint=f"Usage: {cfg.required_env}=xxx zoo task --agent {cfg.name} -p \"...\"",
-    )
-    compose_up([cfg.name, "dashboard"], workspace=workspace)
-    cmd = [arg.replace("{prompt}", prompt) for arg in cfg.task_cmd_template]
-    sys.exit(runner.run_interactive(cmd))
+    sys.exit(api.task(prompt=prompt, agent=agent, workspace=workspace))
 
 
 # === ライフサイクル ===
@@ -83,49 +57,32 @@ def up(
     strict: bool = typer.Option(False, "--strict", help="CoreDNS strict モード"),
 ) -> None:
     """コンテナを起動（起動のみ、exec しない）。"""
-    if dashboard_only:
-        compose_up(["proxy", "dashboard"], workspace=workspace, strict=strict)
-    else:
-        cfg = resolve_agent(agent)
-        compose_up([cfg.name, "dashboard"], workspace=workspace, strict=strict)
+    api.up(agent=agent, workspace=workspace, dashboard_only=dashboard_only, strict=strict)
 
 
 @app.command()
 def down() -> None:
     """コンテナ停止（strict プロファイルも含む）。"""
-    env = compose_env()
-    cmd_strict = [
-        "docker", "compose", "--profile", "strict",
-        "-f", "docker-compose.yml", "-f", "docker-compose.strict.yml",
-        "down",
-    ]
-    result = subprocess.run(cmd_strict, env=env, cwd=repo_root())
-    if result.returncode != 0:
-        run(["docker", "compose", "down"], env=env, check=False)
+    api.down()
 
 
 @app.command()
 def reload() -> None:
     """policy.toml を反映（proxy と dashboard を再起動）。"""
-    cache = repo_root() / "addons" / "__pycache__"
-    if cache.exists():
-        shutil.rmtree(cache)
-    run(["docker", "compose", "restart", "proxy", "dashboard"], env=compose_env())
+    api.reload_policy()
     typer.echo("policy.toml reloaded (cache cleared)")
 
 
 @app.command()
 def build(agent: str = AgentOpt) -> None:
     """Docker イメージをビルド。"""
-    cfg = resolve_agent(agent)
-    ensure_certs()
-    run(["docker", "compose", "build", cfg.name, "dashboard"], env=compose_env())
+    api.build(agent=agent)
 
 
 @app.command()
 def certs() -> None:
     """mitmproxy CA 証明書を生成（既に存在すれば何もしない）。"""
-    ensure_certs()
+    api.certs()
 
 
 # === ホストモード ===
@@ -137,13 +94,13 @@ app.add_typer(host_app, name="host")
 @host_app.command("start")
 def host_start() -> None:
     """ホストモードを起動。"""
-    sys.exit(runner.run_interactive(["./host/setup.sh"]))
+    sys.exit(api.host_start())
 
 
 @host_app.command("stop")
 def host_stop() -> None:
     """ホストモードを停止。"""
-    sys.exit(runner.run_interactive(["./host/stop.sh"]))
+    sys.exit(api.host_stop())
 
 
 # === ログ ===
@@ -155,90 +112,43 @@ app.add_typer(logs_app, name="logs")
 @logs_app.command("clear")
 def logs_clear() -> None:
     """harness.db を削除（WAL/SHM 含む）。"""
-    db = repo_root() / "data" / "harness.db"
-    if not db.exists():
+    if api.logs_clear():
+        typer.echo("Logs cleared (DB + WAL/SHM removed)")
+    else:
         typer.echo("No log database found")
-        return
-    for name in ("harness.db", "harness.db-wal", "harness.db-shm"):
-        p = repo_root() / "data" / name
-        p.unlink(missing_ok=True)
-    typer.echo("Logs cleared (DB + WAL/SHM removed)")
-
-
-def _pipe_to_claude(sqlite_query: str, prompt: str, *, extra_context: str = "") -> None:
-    """sqlite3 の出力を claude -p に流す。"""
-    db_path = repo_root() / "data" / "harness.db"
-    if not db_path.exists():
-        raise SystemExit("data/harness.db が見つかりません。先にエージェントを実行してください。")
-    sqlite = subprocess.Popen(
-        ["sqlite3", str(db_path), "-json", sqlite_query],
-        stdout=subprocess.PIPE,
-    )
-    try:
-        if extra_context:
-            data = sqlite.stdout.read()  # type: ignore[union-attr]
-            sqlite.wait()
-            input_bytes = (extra_context + "\n" + data.decode()).encode()
-            claude = subprocess.Popen(["claude", "-p", prompt], stdin=subprocess.PIPE)
-            claude.stdin.write(input_bytes)  # type: ignore[union-attr]
-            claude.stdin.close()
-            sys.exit(claude.wait())
-        else:
-            claude = subprocess.Popen(["claude", "-p", prompt], stdin=sqlite.stdout)
-            sqlite.stdout.close()  # type: ignore[union-attr]
-            sys.exit(claude.wait())
-    finally:
-        sqlite.wait()
 
 
 @logs_app.command("analyze")
 def logs_analyze() -> None:
     """ブロックログと policy.toml を比較して改善案を生成（ホスト側 claude CLI 必須）。"""
-    query = (
-        "SELECT host, COUNT(*) as n, GROUP_CONCAT(DISTINCT status) as statuses "
-        "FROM requests WHERE status IN ('BLOCKED','RATE_LIMITED','PAYLOAD_BLOCKED') "
-        "GROUP BY host ORDER BY n DESC"
-    )
-    policy = (repo_root() / "policy.toml").read_text()
-    context = f"=== ブロックログ ===\n\n=== 現在のpolicy.toml ===\n{policy}"
-    _pipe_to_claude(
-        query,
-        "ブロックログとpolicy.tomlを比較して改善案をTOML形式で提案して。許可すべきドメインとその理由、危険なドメインとその理由を分けて。",
-        extra_context=context,
-    )
+    try:
+        sys.exit(api.logs_analyze())
+    except FileNotFoundError as e:
+        raise SystemExit(str(e))
 
 
 @logs_app.command("summarize")
 def logs_summarize() -> None:
     """tool_use 履歴からホストモード用の最小権限設定を提案。"""
-    query = "SELECT tool_name, input, input_size, ts FROM tool_uses ORDER BY ts DESC LIMIT 100"
-    _pipe_to_claude(
-        query,
-        "このtool_use履歴からホストモード用settings.jsonの最小権限設定を提案して",
-    )
+    try:
+        sys.exit(api.logs_summarize())
+    except FileNotFoundError as e:
+        raise SystemExit(str(e))
 
 
 @logs_app.command("alerts")
 def logs_alerts() -> None:
     """セキュリティアラートを分析。"""
-    query = "SELECT * FROM alerts ORDER BY ts DESC LIMIT 50"
-    _pipe_to_claude(query, "セキュリティ上の懸念があるパターンを報告して")
+    try:
+        sys.exit(api.logs_alerts())
+    except FileNotFoundError as e:
+        raise SystemExit(str(e))
 
 
 @logs_app.command("candidates")
 def logs_candidates() -> None:
     """policy_candidate.toml に溜まったホワイトリスト候補を一覧表示。"""
-    import tomllib
-
-    candidate_file = repo_root() / "policy_candidate.toml"
-    if not candidate_file.exists():
-        typer.echo("0 candidate(s)")
-        return
-    try:
-        data = tomllib.loads(candidate_file.read_text())
-    except Exception as e:
-        raise SystemExit(f"Parse error: {e}")
-    candidates = data.get("candidates", [])
+    candidates = api.logs_candidates()
     typer.echo(f"{len(candidates)} candidate(s)")
     for c in candidates:
         typer.echo(f"  [{c.get('type','?')}] {c.get('value','?')} - {c.get('reason','')}")
@@ -253,15 +163,13 @@ app.add_typer(test_app, name="test")
 @test_app.command("unit")
 def test_unit() -> None:
     """ユニットテストを実行（pytest）。"""
-    sys.exit(runner.run_interactive(["uv", "run", "python", "-m", "pytest", "tests/", "-v"]))
+    sys.exit(api.test_unit())
 
 
 @test_app.command("smoke")
 def test_smoke(agent: str = AgentOpt) -> None:
     """Docker スモークテスト。まだ Makefile 実装に委譲（複雑なため）。"""
-    env = compose_env()
-    env["AGENT"] = agent
-    sys.exit(subprocess.call(["make", "test", f"AGENT={agent}"], env=env, cwd=repo_root()))
+    sys.exit(api.test_smoke(agent=agent))
 
 
 if __name__ == "__main__":

--- a/tests/test_zoo_api.py
+++ b/tests/test_zoo_api.py
@@ -1,0 +1,159 @@
+"""Tests for the public Python API in zoo.api (subprocess mocked)."""
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+import zoo
+from zoo import api, runner
+
+
+@pytest.fixture
+def repo_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Pretend tmp_path is the agent-zoo repo root."""
+    (tmp_path / "docker-compose.yml").write_text("")
+    (tmp_path / "policy.toml").write_text("")
+    (tmp_path / "data").mkdir()
+    (tmp_path / "certs").mkdir()
+    (tmp_path / "certs" / "mitmproxy-ca-cert.pem").write_text("fake-cert")
+    monkeypatch.chdir(tmp_path)
+    runner.repo_root.cache_clear()
+    yield tmp_path
+    runner.repo_root.cache_clear()
+
+
+class TestPublicExports:
+    def test_api_functions_exposed_at_package_root(self) -> None:
+        for name in (
+            "run", "task", "up", "down", "reload_policy", "build", "certs",
+            "host_start", "host_stop", "logs_clear", "logs_candidates",
+            "logs_analyze", "logs_summarize", "logs_alerts",
+            "test_unit", "test_smoke",
+        ):
+            assert hasattr(zoo, name), f"zoo.{name} missing"
+            assert callable(getattr(zoo, name))
+
+
+class TestLogsClear:
+    def test_returns_false_when_no_db(self, repo_root: Path) -> None:
+        assert api.logs_clear() is False
+
+    def test_removes_db_and_returns_true(self, repo_root: Path) -> None:
+        data_dir = repo_root / "data"
+        (data_dir / "harness.db").write_text("x")
+        (data_dir / "harness.db-wal").write_text("x")
+        (data_dir / "harness.db-shm").write_text("x")
+
+        assert api.logs_clear() is True
+        assert not (data_dir / "harness.db").exists()
+        assert not (data_dir / "harness.db-wal").exists()
+        assert not (data_dir / "harness.db-shm").exists()
+
+
+class TestLogsCandidates:
+    def test_empty_when_file_missing(self, repo_root: Path) -> None:
+        assert api.logs_candidates() == []
+
+    def test_parses_toml(self, repo_root: Path) -> None:
+        (repo_root / "policy_candidate.toml").write_text(
+            '[[candidates]]\n'
+            'type = "domain"\n'
+            'value = "example.com"\n'
+            'reason = "frequently allowed"\n'
+        )
+        result = api.logs_candidates()
+        assert result == [
+            {"type": "domain", "value": "example.com", "reason": "frequently allowed"}
+        ]
+
+
+class TestRun:
+    def test_invokes_compose_up_and_interactive(
+        self, repo_root: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        calls: list[list[str]] = []
+
+        def fake_compose_up(services, **kwargs) -> None:
+            calls.append(["compose_up", *services])
+
+        def fake_interactive(cmd, **kwargs) -> int:
+            calls.append(["interactive", *cmd])
+            return 0
+
+        monkeypatch.setattr(runner, "compose_up", fake_compose_up)
+        monkeypatch.setattr(runner, "run_interactive", fake_interactive)
+
+        assert api.run(agent="claude") == 0
+        assert calls[0] == ["compose_up", "claude", "dashboard"]
+        assert calls[1][0] == "interactive"
+        assert "claude" in calls[1]
+
+    def test_dangerous_flag_selects_dangerous_cmd(
+        self, repo_root: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        captured: dict[str, list[str]] = {}
+
+        monkeypatch.setattr(runner, "compose_up", lambda *a, **kw: None)
+
+        def fake_interactive(cmd, **kwargs) -> int:
+            captured["cmd"] = list(cmd)
+            return 0
+
+        monkeypatch.setattr(runner, "run_interactive", fake_interactive)
+
+        api.run(agent="claude", dangerous=True)
+        assert "--dangerously-skip-permissions" in captured["cmd"]
+
+
+class TestTask:
+    def test_requires_env_var(self, repo_root: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
+        with pytest.raises(SystemExit):
+            api.task(prompt="hello", agent="claude")
+
+    def test_substitutes_prompt(self, repo_root: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", "x")
+        monkeypatch.setattr(runner, "compose_up", lambda *a, **kw: None)
+
+        captured: dict[str, list[str]] = {}
+
+        def fake_interactive(cmd, **kwargs) -> int:
+            captured["cmd"] = list(cmd)
+            return 0
+
+        monkeypatch.setattr(runner, "run_interactive", fake_interactive)
+
+        api.task(prompt="add tests", agent="claude")
+        assert "add tests" in captured["cmd"]
+        assert "{prompt}" not in " ".join(captured["cmd"])
+
+
+class TestInvalidAgent:
+    def test_run_rejects_unknown_agent(self, repo_root: Path) -> None:
+        with pytest.raises(SystemExit):
+            api.run(agent="gpt4")
+
+
+class TestRepoRootDiscovery:
+    def test_walks_up_from_subdir(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        (tmp_path / "docker-compose.yml").write_text("")
+        (tmp_path / "policy.toml").write_text("")
+        sub = tmp_path / "sub" / "dir"
+        sub.mkdir(parents=True)
+        monkeypatch.chdir(sub)
+        runner.repo_root.cache_clear()
+        try:
+            assert runner.repo_root() == tmp_path
+        finally:
+            runner.repo_root.cache_clear()
+
+    def test_errors_outside_repo(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.chdir(tmp_path)
+        runner.repo_root.cache_clear()
+        try:
+            with pytest.raises(SystemExit):
+                runner.repo_root()
+        finally:
+            runner.repo_root.cache_clear()


### PR DESCRIPTION
## Summary
`zoo` を CLI だけでなく Python ライブラリとしても使えるようにした。

```python
import zoo
exit_code = zoo.run(agent="claude", workspace="/path/to/proj")
candidates = zoo.logs_candidates()
```

## 変更点
- `src/zoo/api.py` を新設し、全コマンドを pure function として公開
- `zoo/__init__.py` で再エクスポート (`from zoo import run, task, up, down, ...`)
- `cli.py` を薄い typer ラッパーに書き直し → **typer/rich 依存を CLI 層に閉じ込め**
- API 層は stdlib + tomllib のみ依存
- tests/test_zoo_api.py を追加（subprocess モック、12 ケース）
- docs/python-api.md で使用例を掲載

## 受け入れ基準（Issue #8）
- [x] `from zoo import run, task, up, down, logs_candidates` が動く
- [x] API 層のユニットテスト追加（subprocess モック）
- [x] CLI 層は薄いラッパー（1関数 = API 呼び出し + 終了コード処理）
- [x] `docs/python-api.md` で使用例を掲載

## Test plan
- [x] `uv run python -m pytest tests/` — 179 passed（既存 167 + 新規 12）
- [x] `uv run zoo --help` / 各サブコマンドの `--help` が正常表示
- [x] `python -c "import zoo; print(zoo.__all__)"` で API が見える

## Base / 依存
- base: `feat/zoo-cli` (PR #4)
- Closes #8

#4 が main にマージされ次第 rebase します。