### PR TITLE
:sparkles: release.yml: TestPyPI デプロイ対応 (prd は tag push 専用)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,13 +7,11 @@ on:
   workflow_dispatch:
     inputs:
       target:
-        description: "Deployment target"
+        description: "Deployment target (prd PyPI は tag push 専用)"
         type: choice
         options:
           - none
           - testpypi
-          - pypi
-          - both
         default: testpypi
 
 # 同一タグ / 同一ブランチで重複実行を防ぐ。走行中の release を途中キャンセルしない。
@@ -64,7 +62,7 @@ jobs:
 
   publish-testpypi:
     name: Publish to TestPyPI
-    if: github.event_name == 'workflow_dispatch' && (inputs.target == 'testpypi' || inputs.target == 'both')
+    if: github.event_name == 'workflow_dispatch' && inputs.target == 'testpypi'
     needs: build
     runs-on: ubuntu-latest
     environment:
@@ -85,14 +83,10 @@ jobs:
 
   publish-pypi:
     name: Publish to PyPI
-    # tag push で常時発火、または手動実行で pypi / both が選択された場合。
-    # `both` のときは TestPyPI 成功を待つ（'skipped' は tag push / target=pypi のケース）。
-    if: |
-      always() &&
-      needs.build.result == 'success' &&
-      (needs.publish-testpypi.result == 'success' || needs.publish-testpypi.result == 'skipped') &&
-      (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && (inputs.target == 'pypi' || inputs.target == 'both')))
-    needs: [build, publish-testpypi]
+    # 本番 PyPI は tag push (`v*.*.*`) でのみ発火させる。手動実行 (workflow_dispatch)
+    # からの本番公開は意図的に塞いでいる。
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+    needs: build
     runs-on: ubuntu-latest
     environment:
       name: pypi
@@ -110,7 +104,7 @@ jobs:
 
   github-release:
     name: Create GitHub Release
-    if: startsWith(github.ref, 'refs/tags/')
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
     needs: publish-pypi
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,10 +6,20 @@ on:
       - "v*.*.*"
   workflow_dispatch:
     inputs:
-      dry_run:
-        description: "Build only (no publish)"
-        type: boolean
-        default: true
+      target:
+        description: "Deployment target"
+        type: choice
+        options:
+          - none
+          - testpypi
+          - pypi
+          - both
+        default: testpypi
+
+# 同一タグ / 同一ブランチで重複実行を防ぐ。走行中の release を途中キャンセルしない。
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
   build:
@@ -52,10 +62,37 @@ jobs:
           name: dist
           path: dist/
 
+  publish-testpypi:
+    name: Publish to TestPyPI
+    if: github.event_name == 'workflow_dispatch' && (inputs.target == 'testpypi' || inputs.target == 'both')
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/agent-zoo
+    permissions:
+      id-token: write   # required for OIDC trusted publishing
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to TestPyPI (trusted publishing)
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+
   publish-pypi:
     name: Publish to PyPI
-    if: github.event_name == 'push' || inputs.dry_run == false
-    needs: build
+    # tag push で常時発火、または手動実行で pypi / both が選択された場合。
+    # `both` のときは TestPyPI 成功を待つ（'skipped' は tag push / target=pypi のケース）。
+    if: |
+      always() &&
+      needs.build.result == 'success' &&
+      (needs.publish-testpypi.result == 'success' || needs.publish-testpypi.result == 'skipped') &&
+      (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && (inputs.target == 'pypi' || inputs.target == 'both')))
+    needs: [build, publish-testpypi]
     runs-on: ubuntu-latest
     environment:
       name: pypi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - GitHub Actions CI — pytest (Python 3.11/3.12) と CLI smoke を自動実行
 - PyPI 公開用のメタデータ（classifiers, urls, license など）
 - Release workflow に TestPyPI デプロイ対応 — `workflow_dispatch` の
-  `target` 入力で `none` / `testpypi` / `pypi` / `both` を選択可能。
-  `both` の場合は TestPyPI が成功した時のみ PyPI に公開（フェイルセーフ）。
+  `target` 入力で `none` / `testpypi` を選択可能。本番 PyPI へのリリースは
+  `v*.*.*` タグ push 専用とし、手動実行からの本番公開経路は塞いでいる。
 
 ### Changed
 - `pyproject.toml` を hatchling ビルドに切り替え、assets を wheel に同梱

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   任意ディレクトリに展開
 - GitHub Actions CI — pytest (Python 3.11/3.12) と CLI smoke を自動実行
 - PyPI 公開用のメタデータ（classifiers, urls, license など）
+- Release workflow に TestPyPI デプロイ対応 — `workflow_dispatch` の
+  `target` 入力で `none` / `testpypi` / `pypi` / `both` を選択可能。
+  `both` の場合は TestPyPI が成功した時のみ PyPI に公開（フェイルセーフ）。
 
 ### Changed
 - `pyproject.toml` を hatchling ビルドに切り替え、assets を wheel に同梱
+- Release workflow に `concurrency` グループを追加し、同一 ref での
+  重複実行を直列化（走行中のリリースは中断しない）
 
 ## [0.1.0] - TBD
 

--- a/docs/install-from-package.md
+++ b/docs/install-from-package.md
@@ -12,6 +12,27 @@ uv tool install git+https://github.com/ymdarake/agent-zoo  # 現状はこちら
 pip install agent-zoo
 ```
 
+### TestPyPI (プレリリース検証用)
+
+公式リリース前の動作確認は TestPyPI からインストールできます。
+依存関係は本番 PyPI から解決するために `--extra-index-url` を指定します。
+
+```bash
+# pip
+pip install --index-url https://test.pypi.org/simple/ \
+            --extra-index-url https://pypi.org/simple/ \
+            agent-zoo
+
+# uv tool
+uv tool install --index-url https://test.pypi.org/simple/ \
+                --extra-index-url https://pypi.org/simple/ \
+                agent-zoo
+```
+
+> TestPyPI は同一バージョンの再アップロードを禁じているため、
+> 検証時は `pyproject.toml` の `version` を `.devN` / `rcN` などで
+> インクリメントしてから workflow を再実行してください。
+
 ## セットアップ
 
 任意のディレクトリで `zoo init` を実行すると、パッケージに同梱された


### PR DESCRIPTION
## Summary

- `workflow_dispatch` から **TestPyPI 専用**の手動デプロイ経路を追加（`target` 入力: `none` / `testpypi`、default `testpypi`）
- 新ジョブ `publish-testpypi` を OIDC trusted publishing + `repository-url: https://test.pypi.org/legacy/` で追加
- **本番 PyPI は `v*.*.*` タグ push 専用**に固定（`publish-pypi.if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')`）。手動実行から本番公開する経路は意図的に塞ぐ
- `github-release.if` にも `event_name == 'push'` を明示し、意図を belt-and-suspenders で二重化
- 同一 `github.ref` の重複実行を防ぐ `concurrency` グループを追加（走行中リリースは中断しない）

## 発火マトリクス

| トリガー | build | publish-testpypi | publish-pypi | github-release |
|---|---|---|---|---|
| push tag `v*.*.*` | ✅ | skipped | ✅ | ✅ |
| dispatch target=none | ✅ | skipped | skipped | skipped |
| dispatch target=testpypi | ✅ | ✅ | skipped | skipped |
| build 失敗 | ❌ | skipped | skipped | skipped |

## 運用ポリシー

- **本番 PyPI リリース**: `git tag v0.1.0 && git push origin v0.1.0` のみ
- **TestPyPI 検証**: GitHub Actions → Release to PyPI → Run workflow → `target: testpypi`
- TestPyPI は同一バージョンの再アップロードを禁じているため、検証ループ時は `pyproject.toml` の `version` を `.devN` / `rcN` などでインクリメントする

## 運用側の前提条件

- [x] TestPyPI 側で Trusted Publisher を登録済み (owner: `ymdarake` / repo: `agent-zoo` / workflow: `release.yml` / environment: `testpypi`)
- [x] GitHub リポジトリ Settings → Environments に `testpypi` を作成（protection rule 任意）

## Test plan

- [x] PyYAML で release.yml の構文・構造を検証（ジョブ定義、`target` 入力、各ジョブの `if` 条件、`concurrency`）
- [x] 4 シナリオを条件式ベースで論理トレース（上記マトリクス）
- [x] gemini-cli mcp で設計レビュー計 3 回 — 手動実行から本番 PyPI への経路が完全に閉じていることを確認
- [x] サブエージェントで独立レビュー — 全シナリオの発火判定・式構文を検証
- [ ] マージ後、`workflow_dispatch` → `target=testpypi` で実発火確認
- [ ] 動作問題なければ、タグ push で本番 PyPI への公開経路を発火確認

## 関連ドキュメント更新

- `CHANGELOG.md` — Unreleased に TestPyPI 対応と本番 tag-only ポリシー、`concurrency` を追記
- `docs/install-from-package.md` — TestPyPI からのインストール手順を追記（`--extra-index-url` で本番 PyPI から依存解決する運用を説明）

🤖 Generated with [Claude Code](https://claude.com/claude-code)