### PR TITLE
:bug: release.yml: Extract version の SyntaxError 修正 + Node20 action を Node24 版へ更新

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,10 +26,10 @@ jobs:
     outputs:
       version: ${{ steps.version.outputs.version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
 
@@ -55,7 +55,7 @@ jobs:
           ' >> "$GITHUB_OUTPUT"
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: dist
           path: dist/
@@ -71,7 +71,7 @@ jobs:
     permissions:
       id-token: write   # required for OIDC trusted publishing
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v7
         with:
           name: dist
           path: dist/
@@ -94,7 +94,7 @@ jobs:
     permissions:
       id-token: write   # required for OIDC trusted publishing
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v7
         with:
           name: dist
           path: dist/
@@ -110,9 +110,9 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v7
         with:
           name: dist
           path: dist/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,7 @@ jobs:
           python -c '
           import tomllib, pathlib
           data = tomllib.loads(pathlib.Path("pyproject.toml").read_text())
-          print(f"version={data[\"project\"][\"version\"]}")
+          print("version=" + data["project"]["version"])
           ' >> "$GITHUB_OUTPUT"
 
       - name: Upload artifacts


### PR DESCRIPTION
## Summary

直前のリリース run ([#24350514015](https://github.com/ymdarake/agent-zoo/actions/runs/24350514015)) で出ていた **1 error + 2 warnings** をまとめて解消する。

### 1. `:bug:` Extract version の `SyntaxError` を修正

`Build sdist + wheel → Extract version` ステップが

```
SyntaxError: unexpected character after line continuation character
```

で失敗していた。

**原因**
- Python の f-string 式 (`{...}`) 内部のバックスラッシュは **3.11 以下で禁止**（PEP 701 は 3.12 から緩和）
- runner 既定の `python` は Ubuntu 標準の 3.10/3.11 系
- `uv python install 3.12` は uv 管理配下に Python 3.12 を入れるだけで、PATH 上の `python` は書き換えない
- 結果、3.11 の `python` が `\"` を line continuation として解釈して失敗

**修正**
f-string をやめて文字列連結 (`"version=" + data["project"]["version"]`) に変更。どの Python 3.x でも動作する。

ローカル (Python 3.14) で `version=0.1.0` が出力されることを確認済み。

### 2. `:arrow_up:` Node.js 20 な action を Node 24 版へ更新

同 run で以下の deprecation warning が出ていた:

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: `actions/checkout@v4`, `astral-sh/setup-uv@v3`. Actions will be forced to run with Node.js 24 by default starting **June 2nd, 2026**. Node.js 20 will be removed from the runner on **September 16th, 2026**.

対象を Node 24 対応版へ更新:

| action | 更新前 | 更新後 | 備考 |
|---|---|---|---|
| `actions/checkout` | `v4` | `v5` | Node 24 |
| `astral-sh/setup-uv` | `v3` | `v7` | Node 24 / Astral mirror で rate-limit 回避 |
| `actions/upload-artifact` | `v4` | `v6` | Node 24 (初の Node24 デフォルト) |
| `actions/download-artifact` | `v4` | `v7` | Node 24 (初の Node24 デフォルト) |

artifact 系は上記 warning には出ていなかったが、同じく Node 20 で動いていたため将来の警告回避のため合わせて更新。現状の使い方 (`dist/` を `name: dist` で up/download、checkout はデフォルト、setup-uv は `enable-cache: true` のみ) には破壊的変更なし。

### 3. `:information_source:` Cache service 400 警告

同 run で `Failed to restore: Cache service responded with 400` も出ていた。これは GitHub Actions の新しいキャッシュサービス API (v2) 移行に伴う既知の問題で、古い `@actions/cache` を内部で使う action が引っかかる。setup-uv v7 は内部の @actions/cache を更新しているため、今回のアップグレードで解消が期待できる。

仮に解消しない場合は follow-up で `enable-cache: false` に切り替える。

## Test plan

- [x] ローカル (Python 3.14) で修正後の `python -c` snippet が `version=0.1.0` を出力することを確認
- [x] PyYAML で release.yml 全体の構文を再検証
- [x] 各 action の `v5`/`v6`/`v7` major tag が存在し、`runs.using: node24` になっていることを `gh api` で確認
- [ ] マージ後、`workflow_dispatch` → `target=testpypi` で実発火し、以下を確認:
  - [ ] `Extract version` ステップが成功する
  - [ ] Node 20 deprecation warning が消える
  - [ ] Cache restore 400 warning が消える

🤖 Generated with [Claude Code](https://claude.com/claude-code)