### PR TITLE
Sprint 005 PR C: container hardening (H-3) + Sprint 005 archive

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -30,7 +30,6 @@ active な未完了タスク + 将来計画 (ROADMAP) を統合管理する。
 
 | 優先度 | Sprint | 内容 | 期間 |
 |---|---|---|---|
-| 🔴 **P0** | **Sprint 005** Critical Security | リリース blocker (C-1, C-2, H-1〜H-4) を 3 PR で → **Alpha publish 可** | 2〜3 日 |
 | 🟢 **P2** | **Sprint 006** Security Hardening | Medium (M-2〜M-8) + サプライチェーン hardening を 2 PR で | 2 日 |
 | 🟢 **P2** | **Sprint 007** Dashboard 外部依存ゼロ化 | pico/htmx → 自前 HTML/CSS/JS (ADR 0004) を 4 PR で → **Beta publish 可** | 1〜2 週間 |
 | ⚪ **P3** | **Sprint 008** Low Polish | Low 指摘解消 + 1.0 release candidate | 1 日 |
@@ -83,6 +82,7 @@ active な未完了タスク + 将来計画 (ROADMAP) を統合管理する。
 | 002 | 2026-04-18 | `.zoo/` Workspace Layout Refactor (#29) | [002-dot-zoo-workspace-layout.md](docs/dev/sprints/002-dot-zoo-workspace-layout.md) |
 | 003 | 2026-04-18 | E2E Test Foundation + zoo CLI 一本化 (#33) | [003-e2e-foundation-and-zoo-cli-unification.md](docs/dev/sprints/003-e2e-foundation-and-zoo-cli-unification.md) |
 | 004 | 2026-04-19 | Docs / CI Cleanup (包括レビュー Phase 2) | [004-docs-ci-cleanup.md](docs/dev/sprints/004-docs-ci-cleanup.md) |
+| 005 | 2026-04-18〜19 | Critical Security (包括レビュー Phase 1、C-1/C-2/H-1〜H-4) | [005-critical-security.md](docs/dev/sprints/005-critical-security.md) |
 
 過去の Resolved Decisions（Q1〜Q9 / 案 A 採用 / 命名分離 等）は各 sprint アーカイブを参照。
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **inbox.html 属性 injection / XSS 対策** — `hx-vals` を `|tojson|forceescape` で JSON-safe に。`policy_inbox.list_requests` 側でも glob 取得時に stem を filter (Sprint 005 PR B、包括レビュー H-4)
 - **dashboard セキュリティヘッダ群** — `Content-Security-Policy` (default-src 'self' / frame-ancestors 'none' / base-uri 'none' / object-src 'none'), `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`, `Referrer-Policy: no-referrer` を全レスポンスに付与 (Sprint 005 PR B、Gemini G-2)
 - **dashboard Host ヘッダ whitelist (DNS rebinding 対策)** — `127.0.0.1` / `localhost` 以外の Host ヘッダは 400。`DASHBOARD_ALLOWED_HOSTS` env で override 可能 (Sprint 005 PR B、Gemini G3-B2)
+- **proxy / dashboard / dns コンテナの container hardening** — `cap_drop: [ALL]` + `security_opt: [no-new-privileges:true]` + 非 root `user` 指定。agent コンテナと同等の最小権限化で、container escape や policy 改変の攻撃面を縮小 (Sprint 005 PR C、包括レビュー H-3)
 
 ### Added
 - **Policy Inbox** ([ADR 0001](docs/dev/adr/0001-policy-inbox.md)) — agent が必要な許可 request を `<workspace>/.zoo/inbox/<id>.toml` に submit、dashboard で accept すると `policy.runtime.toml` に自動反映 (Sprint 001)

--- a/bundle/docker-compose.yml
+++ b/bundle/docker-compose.yml
@@ -105,15 +105,30 @@ services:
 
   proxy:
     image: mitmproxy/mitmproxy:10
+    # 包括レビュー H-3: 最小権限 hardening。
+    # - user: 1000 で image の mitmproxy user に合わせる (default entrypoint が
+    #   usermod/chown を要求するため、それを avoid するため entrypoint も override)
+    # - cap_drop: [ALL]: mitmdump は high port (8080) のみ bind、cap 不要
+    # - no-new-privileges: setuid 昇格を封じる
+    # - entrypoint: [""] で docker-entrypoint.sh (usermod 要 CHOWN) を bypass、
+    #   そのまま UID 1000 で mitmdump を exec
+    user: "1000:1000"
+    cap_drop: [ALL]
+    security_opt:
+      - no-new-privileges:true
+    entrypoint: [""]
     environment:
       - PYTHONDONTWRITEBYTECODE=1
     # D-2: certs/extra/bundle.pem があれば上流 TLS 検証に使う（無ければ標準 CA）
-    command: >
-      sh -c "if [ -f /certs/extra/bundle.pem ]; then
-        mitmdump --set confdir=/certs --set ssl_verify_upstream_trusted_ca=/certs/extra/bundle.pem -s /scripts/policy_enforcer.py;
-      else
-        mitmdump --set confdir=/certs -s /scripts/policy_enforcer.py;
-      fi"
+    command:
+      - sh
+      - -c
+      - |
+        if [ -f /certs/extra/bundle.pem ]; then
+          exec mitmdump --set confdir=/certs --set ssl_verify_upstream_trusted_ca=/certs/extra/bundle.pem -s /scripts/policy_enforcer.py
+        else
+          exec mitmdump --set confdir=/certs -s /scripts/policy_enforcer.py
+        fi
     healthcheck:
       test: ["CMD-SHELL", "python3 -c \"import socket; s = socket.create_connection(('localhost', 8080), timeout=2); s.close()\""]
       interval: 5s
@@ -133,6 +148,13 @@ services:
 
   dashboard:
     build: ./dashboard
+    # 包括レビュー H-3: gunicorn を host の UID で run。bind mount (./dashboard,
+    # ./inbox, ./policy.runtime.toml) は host user 権限で read/write されるため
+    # UID 合わせが必要。gunicorn は 8080 (high port) で bind するため cap 不要。
+    user: "${HOST_UID:-1001}:${HOST_UID:-1001}"
+    cap_drop: [ALL]
+    security_opt:
+      - no-new-privileges:true
     ports: ["127.0.0.1:8080:8080"]
     environment:
       - DB_PATH=/data/harness.db
@@ -153,6 +175,13 @@ services:
   dns:
     image: coredns/coredns:1.11.4
     profiles: ["strict"]
+    # 包括レビュー H-3: CoreDNS image は default で UID 65532 (nonroot)。
+    # port 53 < 1024 に bind するため NET_BIND_SERVICE のみ cap_add で復活。
+    cap_drop: [ALL]
+    cap_add:
+      - NET_BIND_SERVICE
+    security_opt:
+      - no-new-privileges:true
     command: -conf /etc/coredns/Corefile
     networks:
       intnet:

--- a/docs/dev/reviews/2026-04-18-comprehensive-review.md
+++ b/docs/dev/reviews/2026-04-18-comprehensive-review.md
@@ -239,7 +239,7 @@ path = Path(inbox_dir) / f"{record_id}.toml"
 
 **修正**: `record_id` を strict regex (`^[A-Za-z0-9T:_-]+$`) でホワイトリスト検証、または `mark_status` 内で `path.resolve().is_relative_to(Path(inbox_dir).resolve())` チェック。`api_inbox_reject` は accept 側と同様に `inbox_list_requests` で存在確認してから渡す。
 
-#### H-3. proxy / dashboard / dns コンテナに `cap_drop` ／ `security_opt` 未適用、root 実行
+#### H-3. proxy / dashboard / dns コンテナに `cap_drop` ／ `security_opt` 未適用、root 実行 — ✅ Sprint 005 PR C で resolved（全 3 service に `cap_drop: [ALL]` + `no-new-privileges` + 非 root user 適用）
 
 **ファイル**: `bundle/docker-compose.yml:106-160`
 

--- a/docs/dev/sprints/005-critical-security.md
+++ b/docs/dev/sprints/005-critical-security.md
@@ -1,0 +1,136 @@
+# Sprint 005: Critical Security Fix
+
+| 項目 | 値 |
+|---|---|
+| 期間 | 2026-04-18〜2026-04-19（2 日） |
+| テーマ | [2026-04-18 包括レビュー](../reviews/2026-04-18-comprehensive-review.md) の Critical + High を一括解消、Alpha publish 可能な状態へ |
+| 親計画 | [2026-04-18 統合作業ブレークダウン](../../plans/2026-04-18-consolidated-work-breakdown.md) Sprint 005 |
+| 完了 PR | #37 (A), #38 (B), #39 (C) |
+| 完了 ADR | [ADR 0005 Fail-closed Addons](../adr/0005-fail-closed-addons.md) |
+
+---
+
+## Sprint Goal
+
+包括レビューで発見された **リリース blocker**（Critical C-1 / C-2、High H-1〜H-4、Gemini G-2 / G3-B2）を 3 PR に分割して解消する:
+
+- **PR A**: mitmproxy addon の fail-closed 化 (C-2)
+- **PR B**: dashboard セキュリティ包括対応 (C-1 / H-1 / H-2 / H-4 / G-2 / G3-B2)
+- **PR C**: container hardening (H-3)
+
+Sprint 完了時点で Alpha release 可能な状態を目指す（Phase 1 完全完了）。
+
+---
+
+## Decisions
+
+### PR A: mitmproxy addon fail-closed（ADR 0005）
+
+| # | 決定 | 結果 |
+|---|---|---|
+| A1 | hook 種別ごとの decorator を用意（`fail_closed_block` / `_ws_message` / `_lifecycle`） | ✅ `bundle/addons/_fail_closed.py` |
+| A2 | `policy_enforcer.py` の全 5 event hook に適用 | ✅ request / response / websocket_message / websocket_end / done |
+| A3 | mitmproxy 制御例外 (`AddonHalt` / `OptionsError`) は透過 | ✅ `_MITMPROXY_CONTROL_EXCEPTIONS` 動的収集 |
+| A4 | WebSocket drop 失敗時の最終防衛線として `flow.kill()` | ✅ Gemini review 反映 |
+| A5 | ctx.log 失敗時 stderr fallback の 2 段防御 | ✅ |
+| A6 | 14 テスト (正常 / 例外 / 既存 response 保護 / drop 失敗 / ctx 不在 / 既存 response 上書き / 制御例外透過) | ✅ |
+
+### PR B: dashboard セキュリティ包括
+
+| # | 決定 | 結果 |
+|---|---|---|
+| B1 | `FLASK_DEBUG=1` 撤去、`gunicorn` 復元 (C-1) | ✅ `docker-compose.yml` |
+| B2 | Flask-WTF CSRFProtect 導入 (H-1) | ✅ `<body hx-headers>` で HTMX 自動送出 + `meta` tag で fetch() 送出 |
+| B3 | record_id strict regex + `path.resolve().is_relative_to` 2 段防御 (H-2) | ✅ policy_inbox / dashboard 両層で検証 |
+| B4 | `hx-vals` を `|tojson|forceescape` で JSON-safe 化 + stem filter (H-4) | ✅ |
+| B5 | CSP + X-CTO + X-Frame-Options + Referrer-Policy (G-2) | ✅ `@app.after_request` |
+| B6 | Strict Host middleware (G3-B2) | ✅ IPv6 / case / trailing dot / 不正 port 全対応 |
+| B7 | 38 テスト追加 (CSRF / path traversal / security headers) | ✅ |
+
+### PR C: container hardening (H-3)
+
+| # | 決定 | 結果 |
+|---|---|---|
+| C1 | proxy: `user: 1000 + cap_drop [ALL] + no-new-privileges + entrypoint bypass` | ✅ mitmdump を非 root + 無 cap で直接 exec |
+| C2 | dashboard: `user: HOST_UID + cap_drop [ALL] + no-new-privileges` | ✅ gunicorn が host UID で run |
+| C3 | dns: `cap_drop [ALL] + cap_add [NET_BIND_SERVICE] + no-new-privileges` | ✅ CoreDNS の port 53 bind を許容 |
+| C4 | 実機 `docker compose up -d` で proxy PID 1 = UID 1000 + CapBnd=0、dashboard PID 1 = UID 502 + CapBnd=0 確認 | ✅ |
+
+---
+
+## Commit Log
+
+```
+# PR A (#37) — 2026-04-18 merged
+78f21d2 :white_check_mark: addons/_fail_closed: mitmproxy addon 用 fail-closed decorator + test
+77e5a11 :lock: policy_enforcer: 全 mitmproxy event hook に fail-closed decorator を適用
+a81c565 :memo: ADR 0005 fail-closed addons + architecture / CHANGELOG / review 更新
+ddbadf9 :memo: Sprint 005 PR A self-review 反映: 制御例外透過 / 追加テスト / stderr 2 段 / ADR 拡充
+9b7f542 :lock: Gemini review 反映: WebSocket drop 失敗時の flow.kill() 最終防衛線
+
+# PR B (#38) — 2026-04-18 merged
+142c880 :lock: docker-compose.yml: dashboard の FLASK_DEBUG=1 撤去 (C-1)
+1a55ebf :lock: dashboard: CSRF 対策 (Flask-WTF CSRFProtect) 導入 (H-1)
+54d5863 :lock: inbox: record_id の path traversal 対策 (H-2)
+2af3b62 :lock: dashboard: HTMX 属性 injection / XSS / CSP / DNS rebinding 対策 (H-4 / G-2 / G3-B2)
+1f42044 :memo: CHANGELOG + 包括レビューに Sprint 005 PR B の resolved マーク + uv.lock 更新
+4184824 :recycle: Sprint 005 PR B self-review 反映: Host 正規化 / IPv6 対応 / SECRET_KEY 強化 / test 拡張
+6016dc6 :lock: Gemini review 反映: Host 正規化強化 (port / trailing dot / case)
+
+# PR C (#39)
+82b6461 :lock: docker-compose: proxy / dashboard / dns に container hardening (H-3)
+# （本 archive + 残 docs commit が続く）
+```
+
+---
+
+## 検証
+
+| 項目 | 結果 |
+|---|---|
+| `make unit` (全テスト) | **287 PASS** (Sprint 005 で +53 tests) |
+| `make e2e` (P1 dashboard) | **7 PASS** |
+| CI `e2e-proxy` (post-merge) | PR A / B の main push で自動実行済 |
+| 実機 `docker compose up -d` (PR C) | proxy UID 1000 / dashboard UID 502、両 CapBnd=0 |
+| 包括レビュー Critical / High の resolved マーク | C-1 / C-2 / H-1 / H-2 / H-3 / H-4 すべて ✅ |
+
+---
+
+## 学び / 次に活かす
+
+### Fail-closed 設計は「契約」
+
+addon が例外で死ぬと mitmproxy は flow を pass-through する (fail-open) という仕様を知ったのは Gemini レビュー経由。「セキュリティ製品が壊れたら **必ず deny**」は明文化されていない暗黙契約だったが、今回 ADR 0005 として明示した。将来 hook 追加時も decorator 漏れをレビューで catch できる。
+
+### 「localhost bind = 安全」は幻想
+
+dashboard は `127.0.0.1:8080` bind だが、ブラウザ経由 CSRF + DNS rebinding で外部 origin から操作可能 (G3-B2)。HTTP API を公開している限り Origin / Host / CSRF の防御は必須。Flask-WTF CSRFProtect + Strict Host middleware で localhost 前提の甘えを解消。
+
+### Docker image entrypoint の CHOWN 要件
+
+mitmproxy/mitmproxy:10 image は `docker-entrypoint.sh` で `usermod` を呼ぶため、`cap_drop: [ALL]` だけでは container 起動が失敗する。`entrypoint: [""]` で bypass し、`user: 1000` で直接 mitmdump を起動することで cap 完全剥奪と両立。この種の「image 側の root 前提 init」対応は他の container でも今後必要になる。
+
+### 2 段防御 (defense-in-depth) の具体例
+
+`record_id` の path traversal 対策で、以下 2 層を両方実装:
+1. **regex whitelist** (`^[A-Za-z0-9T:_-]+$`) - 表層、入力 validation
+2. **`path.resolve().is_relative_to(inbox_resolved)`** - 深層、symlink / encoding bypass を物理的に阻止
+
+どちらか 1 つでも強固だが、両方実装することで「regex を誰かが後で緩めても symlink bypass が効かない」「symlink 実装がバグっても regex で弾ける」相互保険が効く。テストも両層で独立検証。
+
+### Self-review + Gemini の相互補完
+
+- **Claude subagent** (一次 / 静的解析): コード整合性、テスト漏れ、false positive 候補
+- **Gemini 2.5 Pro** (セカンドオピニオン / 設計面): アーキテクチャ盲点、既知仕様 (mitmproxy fail-open, DNS rebinding)
+- **Gemini 3 Flash Preview** (サードオピニオン / 裏取り): Claude/Gemini 2.5 が見逃した仕様確認 (drop() → flow.kill()、Host 正規化)
+
+3 層レビュー体制で Critical 1 + High 1 + Medium 複数の追加検出があり、Claude 単体では気付けなかった。
+
+---
+
+## 参照
+
+- ADR 0005 [Fail-closed Addons](../adr/0005-fail-closed-addons.md)
+- 包括レビュー [2026-04-18](../reviews/2026-04-18-comprehensive-review.md)
+- 統合作業計画 [Sprint 005 節](../../plans/2026-04-18-consolidated-work-breakdown.md#sprint-005-critical-security-fix2〜3-日3-pr)
+- PR: #37 (A), #38 (B), #39 (C)


### PR DESCRIPTION
## 概要

[2026-04-18 包括レビュー](../blob/main/docs/dev/reviews/2026-04-18-comprehensive-review.md) **High H-3** を解消する Sprint 005 の最終 PR。

agent コンテナには既に `cap_drop: [ALL]` が適用されていたが、**proxy / dashboard / dns** は root + 全 cap 保持で動作していた。container escape や policy 改変の攻撃面を縮小するため同等の最小権限化を適用。

## 変更内容

### bundle/docker-compose.yml — 3 service を hardening

| service | 設定 | 備考 |
|---|---|---|
| **proxy** | `user: "1000:1000"` + `cap_drop: [ALL]` + `no-new-privileges` + `entrypoint: [""]` bypass | mitmproxy image の docker-entrypoint.sh が usermod/chown を要求するため bypass し直接 mitmdump を exec |
| **dashboard** | `user: "${HOST_UID:-1001}:${HOST_UID:-1001}"` + `cap_drop: [ALL]` + `no-new-privileges` | gunicorn を host UID で run、bind mount 互換 |
| **dns** (strict) | `cap_drop: [ALL]` + `cap_add: [NET_BIND_SERVICE]` + `no-new-privileges` | CoreDNS の port 53 bind のため NET_BIND_SERVICE のみ復活 |

### Sprint 005 archive 作成 + 包括レビュー更新

- `docs/dev/sprints/005-critical-security.md` 新規: PR A+B+C の全決定事項集約
- 包括レビュー H-3 に ✅ resolved マーク追加
- CHANGELOG ### Security に H-3 項目追加
- BACKLOG: Next Up から Sprint 005 削除、Sprint 履歴に 005 追加

## 検証

**実機 Docker Desktop で確認済**:

```
$ docker compose exec proxy sh -c 'cat /proc/1/status | grep -iE "^uid|^cap"'
Uid:    1000    1000    1000    1000
CapBnd: 0000000000000000   ← 全 cap 剥奪

$ docker compose exec dashboard sh -c 'cat /proc/1/status | grep -iE "^uid|^cap"'
Uid:    502    502    502    502    ← host UID
CapBnd: 0000000000000000
```

- [x] `make unit` **287 PASS**
- [x] `make e2e` **7 PASS**
- [x] 実機 `docker compose up -d proxy dashboard` で両 container healthy、PID 1 非 root + CapBnd=0
- [x] `main` push 時に `e2e-proxy` job (CI) が proxy 疎通を自動検証

## Sprint 005 完了

本 PR merge で **Sprint 005 が完全完了** = **Alpha release 可能な状態** になります:
- Critical 2 件 (C-1, C-2) 解消
- High 4 件 (H-1, H-2, H-3, H-4) 解消
- Gemini 追加 2 件 (G-2, G3-B2) 解消

## 関連

- Sprint 005 アーカイブ: [docs/dev/sprints/005-critical-security.md](../blob/fix/sprint-005-pr-c-container-hardening/docs/dev/sprints/005-critical-security.md)
- 前: Sprint 005 PR A (#37), PR B (#38) 両 merged
- 次: Sprint 006 Security Hardening Medium (M-2〜M-8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)