### PR TITLE
:sparkles: Sprint 007 PR G: 自前 CSS + vanilla JS 基盤追加

### DIFF
--- a/bundle/dashboard/app.py
+++ b/bundle/dashboard/app.py
@@ -62,6 +62,11 @@ app.config["SECRET_KEY"] = (
 )
 # HTMX からの token 送出を header ベースで許容（body だけでなく X-CSRFToken を読む）
 app.config["WTF_CSRF_HEADERS"] = ["X-CSRFToken", "X-CSRF-Token"]
+
+# Sprint 007 PR G (ADR 0004): asset cache busting 用 version。env 未設定時は空文字
+# default で Jinja UndefinedError を回避。PR I で git short sha 等の注入を検討。
+# `?v={{ asset_version }}` を template 側で defensive に出すパターンが Plan G review G3。
+app.config["ASSET_VERSION"] = os.environ.get("ASSET_VERSION", "")
 # Flask-WTF 1.2.x は TESTING=True でも CSRF を自動無効化しない。既存 test は setUp で
 # `app.config["WTF_CSRF_ENABLED"] = False` を明示指定している。CSRF 動作検証は
 # test_dashboard_csrf.py で WTF_CSRF_ENABLED=True にして実施。

--- a/bundle/dashboard/static/app.css
+++ b/bundle/dashboard/static/app.css
@@ -1,0 +1,284 @@
+/*
+ * agent-zoo dashboard — 自前 CSS (Sprint 007 PR G)
+ *
+ * 設計の正本:
+ *   docs/dev/adr/0004-dashboard-external-deps-removal.md
+ *
+ * design tokens は :root にフラット定義 (将来 dark theme で
+ *   @media (prefers-color-scheme: dark) { :root { --color-text: ...; } }
+ *   で同名変数を上書きするだけで切替可能な構造)。
+ */
+
+/* === design tokens === */
+:root {
+  --font-size-base: 14px;
+  --color-muted: #6b7280;
+  --color-primary: #1a73e8;
+  --color-text: #1f2937;
+  --color-bg: #ffffff;
+  --color-border: #e5e7eb;
+  --color-danger: #d11a2a;
+  --color-success: #188038;
+
+  --badge-allowed-bg: #d4edda;
+  --badge-allowed-fg: #155724;
+  --badge-blocked-bg: #f8d7da;
+  --badge-blocked-fg: #721c24;
+  --badge-rate-limited-bg: #fff3cd;
+  --badge-rate-limited-fg: #856404;
+
+  --radius-sm: 4px;
+  --radius-md: 6px;
+  --space-1: 0.25rem;
+  --space-2: 0.5rem;
+  --space-3: 1rem;
+  --space-4: 1.5rem;
+}
+
+/* === base reset === */
+*, *::before, *::after { box-sizing: border-box; }
+
+html { font-size: var(--font-size-base); }
+
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Hiragino Sans",
+               "Helvetica Neue", Arial, sans-serif;
+  color: var(--color-text);
+  background: var(--color-bg);
+  line-height: 1.5;
+}
+
+/* === layout === */
+.layout-container {
+  width: 100%;
+  margin-inline: auto;
+  padding-inline: 1rem;
+  max-width: 1280px;
+}
+
+@media (min-width: 768px)  { .layout-container { max-width: 720px; } }
+@media (min-width: 1024px) { .layout-container { max-width: 960px; } }
+@media (min-width: 1280px) { .layout-container { max-width: 1200px; } }
+
+/* === typography === */
+h1, h2, h3, h4, h5 { margin: 0 0 var(--space-2) 0; line-height: 1.25; }
+h1 { font-size: 1.5rem; }
+h2 { font-size: 1.25rem; }
+h3 { font-size: 1.125rem; }
+h4 { font-size: 1rem; }
+h5 { font-size: 0.875rem; }
+p { margin: 0 0 var(--space-2) 0; }
+small { color: var(--color-muted); font-size: 0.85em; }
+code {
+  background: #f3f4f6;
+  padding: 1px 4px;
+  border-radius: var(--radius-sm);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.85em;
+}
+
+/* === nav === */
+.app-nav {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: var(--space-3) 0;
+  border-bottom: 1px solid var(--color-border);
+  margin-bottom: var(--space-3);
+}
+.app-nav h1 { margin: 0; font-size: 1.25rem; }
+.app-nav small { font-size: 0.875rem; }
+
+/* === card (article 代替) === */
+.card {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  padding: var(--space-3);
+  background: var(--color-bg);
+}
+
+/* === stat grid === */
+.stat-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: var(--space-3);
+  margin-bottom: var(--space-4);
+}
+.stat-card {
+  text-align: center;
+  padding: var(--space-3);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+}
+.stat-card h2 { margin: 0; font-size: 2rem; }
+.stat-card small { color: var(--color-muted); }
+
+/* === table === */
+table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.85rem;
+}
+th, td {
+  padding: var(--space-2);
+  border-bottom: 1px solid var(--color-border);
+  text-align: left;
+  vertical-align: top;
+}
+th { font-weight: 600; background: #f9fafb; }
+
+/* === form / input / button === */
+form { margin: 0; }
+input[type="text"], input[type="search"], select {
+  padding: var(--space-1) var(--space-2);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  font-size: 0.85rem;
+  font-family: inherit;
+}
+input[type="text"]:focus, select:focus { outline: 2px solid var(--color-primary); outline-offset: 1px; }
+
+button {
+  padding: var(--space-1) var(--space-3);
+  border: 1px solid var(--color-primary);
+  border-radius: var(--radius-sm);
+  background: var(--color-primary);
+  color: white;
+  font-family: inherit;
+  font-size: 0.85rem;
+  cursor: pointer;
+}
+button:hover { filter: brightness(1.05); }
+button:active { transform: translateY(1px); }
+
+.btn-sm { padding: var(--space-1) var(--space-2); font-size: 0.75rem; }
+.btn-secondary { background: #6b7280; border-color: #6b7280; }
+.btn-contrast { background: #1f2937; border-color: #1f2937; }
+.btn-outline { background: transparent; color: var(--color-primary); }
+.btn-danger-text { background: transparent; border-color: transparent; color: var(--color-danger); padding: 1px 4px; font-size: 0.65rem; }
+
+/* === status badge (status-* 単独 selector で badge と数値強調を両用) === */
+.status-badge {
+  padding: 2px 8px;
+  border-radius: var(--radius-sm);
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+.status-ALLOWED { background: var(--badge-allowed-bg); color: var(--badge-allowed-fg); }
+.status-BLOCKED,
+.status-PAYLOAD_BLOCKED,
+.status-URL_SECRET_BLOCKED,
+.status-BODY_TOO_LARGE { background: var(--badge-blocked-bg); color: var(--badge-blocked-fg); }
+.status-RATE_LIMITED { background: var(--badge-rate-limited-bg); color: var(--badge-rate-limited-fg); }
+
+/* stats partial の <h2 class="status-BLOCKED"> は背景色を継承しつつ size を保つ
+   (badge selector と独立して機能、padding なし) */
+.stat-card h2.status-ALLOWED,
+.stat-card h2.status-BLOCKED,
+.stat-card h2.status-PAYLOAD_BLOCKED,
+.stat-card h2.status-RATE_LIMITED { padding: 0; background: transparent; color: var(--badge-blocked-fg); }
+
+/* === tab nav === */
+.tab-nav { display: flex; gap: 0; margin-bottom: var(--space-4); border-bottom: 1px solid var(--color-border); }
+.tab-nav a {
+  padding: var(--space-2) var(--space-4);
+  border-bottom: 2px solid transparent;
+  text-decoration: none;
+  color: var(--color-muted);
+  cursor: pointer;
+  margin-bottom: -1px;
+}
+.tab-nav a.active { border-bottom-color: var(--color-primary); color: var(--color-text); }
+.tab-nav a:hover { color: var(--color-text); }
+
+/* === badges and misc === */
+.badge {
+  background: var(--color-danger);
+  color: white;
+  padding: 1px 6px;
+  border-radius: var(--radius-sm);
+  font-size: 0.7rem;
+  margin-left: var(--space-1);
+}
+
+/* === spinner (aria-busy 代替) === */
+.spinner {
+  display: inline-block;
+  width: 1em;
+  height: 1em;
+  border: 2px solid var(--color-border);
+  border-top-color: var(--color-primary);
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+  vertical-align: middle;
+}
+@keyframes spin { to { transform: rotate(360deg); } }
+
+[aria-busy="true"]::before {
+  content: "";
+  display: inline-block;
+  width: 1em;
+  height: 1em;
+  border: 2px solid var(--color-border);
+  border-top-color: var(--color-primary);
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+  margin-right: var(--space-1);
+  vertical-align: middle;
+}
+
+/* === url-suggest 既適用マーク (inline style 排除) === */
+.suggest-applied { color: var(--color-primary); }
+
+/* === utility === */
+.flex { display: flex; }
+.inline-flex { display: inline-flex; }
+.gap-1 { gap: var(--space-1); }
+.gap-2 { gap: var(--space-2); }
+.items-center { align-items: center; }
+.mb-1 { margin-bottom: var(--space-1); }
+.mb-2 { margin-bottom: var(--space-2); }
+.mb-3 { margin-bottom: var(--space-3); }
+.nowrap { white-space: nowrap; }
+.text-muted { color: var(--color-muted); }
+.text-success { color: var(--color-success); }
+.text-danger { color: var(--color-danger); }
+.text-primary { color: var(--color-primary); }
+.text-runtime { color: var(--color-primary); }
+.text-base-policy { color: var(--color-muted); }
+.fw-600 { font-weight: 600; }
+.fs-xs { font-size: 0.7rem; }
+.fs-sm { font-size: 0.75rem; }
+
+/* code / path display in tables */
+.path-cell {
+  max-width: 400px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.8rem;
+}
+
+/* runtime 由来のドメイン/path を強調表示 (base と区別) */
+.runtime-marker {
+  border: 1px solid var(--color-primary);
+  padding: 1px 4px;
+  border-radius: var(--radius-sm);
+}
+
+/* form inline (table 内の小さな form) */
+.form-inline { display: inline-flex; gap: var(--space-1); align-items: center; }
+.form-inline input[type="text"] { width: 120px; }
+
+/* utility for "click-to-suggest" ul */
+.url-suggest-list { margin: 0; padding-left: var(--space-3); }
+.url-suggest-list li {
+  cursor: pointer;
+  text-decoration: underline;
+  word-break: break-all;
+}
+
+/* hidden tab content (JS で display 制御するが、初期 hidden をマークアップで表現) */
+.hidden { display: none; }

--- a/bundle/dashboard/static/app.js
+++ b/bundle/dashboard/static/app.js
@@ -1,0 +1,240 @@
+/**
+ * agent-zoo dashboard — vanilla JS (Sprint 007 PR G)
+ *
+ * 設計の正本:
+ *   docs/dev/adr/0004-dashboard-external-deps-removal.md
+ *   docs/plans/sprint-007-pr-f.md (pseudo-code)
+ *
+ * Declarative API (data-* 属性):
+ *   data-poll-url / data-poll-interval / data-swap-target
+ *   data-trigger-from / data-include
+ *   data-confirm / data-json-body
+ *   data-tab
+ *   data-bulk-action / data-bulk-select / data-bulk-target / data-bulk-confirm
+ *   data-suggest-target
+ */
+(function () {
+  'use strict';
+
+  // === Helpers ===
+  // CSRF token は **毎 fetch ごと** meta tag から読む (rotation 対応、抽出保持禁止)
+  const csrf = () => {
+    const m = document.querySelector('meta[name="csrf-token"]');
+    return m ? m.content : '';
+  };
+
+  function buildIncludeQuery(includeSel) {
+    if (!includeSel) return '';
+    const params = new URLSearchParams();
+    document.querySelectorAll(includeSel).forEach((el) => {
+      if (el.name) params.append(el.name, el.value);
+    });
+    const qs = params.toString();
+    return qs ? '?' + qs : '';
+  }
+
+  function swapInto(targetSel, html) {
+    if (!targetSel) return;
+    const el = document.querySelector(targetSel);
+    if (el) el.innerHTML = html;
+  }
+
+  // === GET polling (with exponential backoff on error) ===
+  // _pollTimers: element → { intervalId, failures, baseInterval }
+  const _pollTimers = new WeakMap();
+  const MAX_BACKOFF_MS = 60 * 1000;
+
+  function _scheduleInterval(el, ms) {
+    const state = _pollTimers.get(el);
+    if (!state) return;
+    if (state.intervalId) clearInterval(state.intervalId);
+    state.intervalId = setInterval(() => {
+      if (document.hidden) return;
+      pollOnce(el);
+    }, ms);
+  }
+
+  async function pollOnce(el) {
+    if (!el.dataset.pollUrl) return;
+    const url = el.dataset.pollUrl + buildIncludeQuery(el.dataset.include);
+    try {
+      const res = await fetch(url, { headers: { 'HX-Request': 'true' } });
+      if (!res.ok) throw new Error('HTTP ' + res.status);
+      const html = await res.text();
+      if (el.dataset.swapTarget) {
+        swapInto(el.dataset.swapTarget, html);
+      } else {
+        el.innerHTML = html;
+      }
+      const state = _pollTimers.get(el);
+      if (state && state.failures > 0) {
+        state.failures = 0;
+        _scheduleInterval(el, state.baseInterval);
+      }
+    } catch (e) {
+      console.warn('poll failed', url, e);
+      const state = _pollTimers.get(el);
+      if (state) {
+        state.failures += 1;
+        const next = Math.min(
+          state.baseInterval * Math.pow(2, state.failures),
+          MAX_BACKOFF_MS
+        );
+        _scheduleInterval(el, next);
+      }
+    }
+  }
+
+  function setupPolls(root) {
+    root = root || document;
+    const nodes = root.querySelectorAll
+      ? root.querySelectorAll('[data-poll-url]')
+      : [];
+    nodes.forEach((el) => {
+      if (_pollTimers.has(el)) return;
+      let baseInterval = parseInt(el.dataset.pollInterval || '5000', 10);
+      if (isNaN(baseInterval) || baseInterval <= 0) baseInterval = 5000;
+      _pollTimers.set(el, { intervalId: 0, failures: 0, baseInterval });
+      pollOnce(el); // 即時
+      _scheduleInterval(el, baseInterval);
+
+      if (el.dataset.triggerFrom) {
+        const [sel, ev] = el.dataset.triggerFrom.split(':');
+        document.body.addEventListener(ev || 'change', (e) => {
+          if (e.target.closest && e.target.closest(sel)) pollOnce(el);
+        });
+      }
+    });
+  }
+
+  // === Form submit (data-swap-target) ===
+  document.body.addEventListener('submit', async (ev) => {
+    const form = ev.target;
+    if (!form.matches || !form.matches('form[data-swap-target]')) return;
+    ev.preventDefault();
+    if (form.dataset.confirm && !confirm(form.dataset.confirm)) return;
+    const headers = { 'X-CSRFToken': csrf(), 'HX-Request': 'true' };
+    let body;
+    if (form.dataset.jsonBody) {
+      body = form.dataset.jsonBody;
+      headers['Content-Type'] = 'application/json';
+    } else {
+      body = new FormData(form);
+    }
+    try {
+      // Gemini レビュー Medium #4: form.method (property) は HTML 未指定時 'get' を返す
+      // ため、`form.method || 'POST'` は常に form.method 採用で POST fallback が効かない。
+      // form.getAttribute('method') は未指定時 null → 'POST' fallback 正常動作。
+      const method = (form.getAttribute('method') || 'POST').toUpperCase();
+      const res = await fetch(form.action, { method, headers, body });
+      const html = await res.text();
+      swapInto(form.dataset.swapTarget, html);
+    } catch (e) {
+      console.warn('form submit failed', form.action, e);
+    }
+  });
+
+  // === Tab nav (data-tab) ===
+  document.body.addEventListener('click', (ev) => {
+    const tab = ev.target.closest && ev.target.closest('[data-tab]');
+    if (!tab) return;
+    ev.preventDefault();
+    const name = tab.dataset.tab;
+    document.querySelectorAll('[id^="tab-"]').forEach((t) => {
+      t.classList.add('hidden');
+    });
+    const target = document.getElementById('tab-' + name);
+    if (target) target.classList.remove('hidden');
+    document
+      .querySelectorAll('[data-tab]')
+      .forEach((a) => a.classList.remove('active'));
+    tab.classList.add('active');
+  });
+
+  // === Bulk action (data-bulk-action) ===
+  document.body.addEventListener('click', async (ev) => {
+    const btn = ev.target.closest && ev.target.closest('[data-bulk-action]');
+    if (!btn) return;
+    ev.preventDefault();
+    const scope =
+      (btn.closest && btn.closest('[data-bulk-scope]')) || document;
+    const ids = Array.from(
+      scope.querySelectorAll('[data-bulk-select]:checked')
+    ).map((cb) => cb.value);
+    if (ids.length === 0) {
+      alert('選択してください');
+      return;
+    }
+    if (btn.dataset.bulkConfirm && !confirm(btn.dataset.bulkConfirm)) return;
+    try {
+      const res = await fetch(btn.dataset.bulkAction, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'HX-Request': 'true',
+          'X-CSRFToken': csrf(),
+        },
+        body: JSON.stringify({ record_ids: ids }),
+      });
+      const html = await res.text();
+      swapInto(btn.dataset.bulkTarget, html);
+    } catch (e) {
+      console.warn('bulk action failed', btn.dataset.bulkAction, e);
+    }
+  });
+
+  // === URL suggest (data-suggest-target on <li data-url=...>) ===
+  document.body.addEventListener('click', (ev) => {
+    const li =
+      ev.target.closest &&
+      ev.target.closest('li[data-url][data-suggest-target]');
+    if (!li) return;
+    try {
+      const u = new URL(li.dataset.url);
+      const p = u.pathname;
+      const v =
+        p.lastIndexOf('/') > 0
+          ? p.substring(0, p.lastIndexOf('/')) + '/*'
+          : p + '*';
+      const target = document.querySelector(li.dataset.suggestTarget);
+      if (target) target.value = v;
+      li.classList.add('suggest-applied');
+    } catch (_) {
+      /* invalid URL → silently skip */
+    }
+  });
+
+  // === MutationObserver: addedNodes / removedNodes 両方で自身+子孫を走査 ===
+  const mo = new MutationObserver((muts) => {
+    muts.forEach((m) => {
+      m.addedNodes.forEach((n) => {
+        if (n.nodeType === 1) setupPolls(n);
+      });
+      m.removedNodes.forEach((n) => {
+        if (n.nodeType !== 1) return;
+        const targets = [];
+        if (n.matches && n.matches('[data-poll-url]')) targets.push(n);
+        if (n.querySelectorAll) {
+          n.querySelectorAll('[data-poll-url]').forEach((el) =>
+            targets.push(el)
+          );
+        }
+        targets.forEach((el) => {
+          const state = _pollTimers.get(el);
+          if (state) {
+            clearInterval(state.intervalId);
+            _pollTimers.delete(el);
+          }
+        });
+      });
+    });
+  });
+  mo.observe(document.body, { childList: true, subtree: true });
+
+  // === Boot ===
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', () => setupPolls());
+  } else {
+    setupPolls();
+  }
+})();

--- a/docs/plans/sprint-007-pr-g.md
+++ b/docs/plans/sprint-007-pr-g.md
@@ -1,0 +1,219 @@
+# Sprint 007 PR G: 自前 CSS + vanilla JS 基盤
+
+| 項目 | 値 |
+|---|---|
+| 作成日 | 2026-04-19 |
+| 改訂 | Rev.3（実装 self-review 反映: 実態 line 数 + data-bulk-scope 補注 + fetch 失敗時 UI swap follow-up） |
+| Sprint | 007 |
+| PR | F (✅ merged) → **G (本 PR)** → H → I |
+| 親設計 | [ADR 0004](../dev/adr/0004-dashboard-external-deps-removal.md) (Rev.4) |
+| 親計画 | [Plan F](sprint-007-pr-f.md) (Rev.4) — pseudo-code 正本 |
+
+---
+
+## ゴール
+
+PR F で確定した設計に基づき、**自前 CSS + vanilla JS の基盤ファイルを追加**する。
+**index.html はまだ link しない**（PR H で link）。Flask の static serving 確認のみ。
+
+### Deliverables
+
+1. `bundle/dashboard/static/app.css` — 自前 CSS (~250〜350 行のレンジ、超過時は PR H で追加 commit OK)。design tokens / layout / table / form / button / status badge / spinner。**`:root` 変数はフラット定義** (将来 dark theme で `@media (prefers-color-scheme: dark)` 内で同名変数を上書き可能な構造に)
+2. `bundle/dashboard/static/app.js` — Plan F pseudo-code を実体化 (**実装後 ~240 行**: 実 logic ~165 行 + コメント・正本リンク 50 行 + IIFE wrap + defensive guards 20 行。Plan G Rev.2 では 120〜150 を見積もったが、Plan F Rev.4 の Critical 要素 (backoff / MutationObserver 子孫走査 / defensive guard / IIFE / 仕様正本リンクコメント) を全部含めると 240 行になる)。**防御的設計**: `if (!el.dataset.pollUrl) return;` ガード、`isNaN(baseInterval)` 時 fallback (5000ms)
+3. `bundle/dashboard/app.py` — `app.config["ASSET_VERSION"] = os.environ.get("ASSET_VERSION", "")` default 設定 (Jinja UndefinedError 回避)
+4. `tests/test_dashboard_static.py`(新規) — `/static/app.css`、`/static/app.js` の 200 配信確認 + **重要 API 識別子 (MutationObserver / removedNodes / _pollTimers / document.hidden) の含有 assert** で pseudo-code 必須要素の欠落を防止
+5. `tests/test_dashboard_asset_version.py`(新規) — `ASSET_VERSION` config の default 確認
+
+### Non-goals
+
+- index.html / partials の書換（PR H）
+- CDN link 削除 / CSP 厳格化（PR I）
+- E2E test の selector 変更（PR H）
+
+---
+
+## 作業順 (TDD)
+
+### 1. Red: テスト追加 (PASS しない)
+
+`tests/test_dashboard_static.py`:
+
+```python
+class TestStaticAssets(unittest.TestCase):
+    def setUp(self):
+        app.config["TESTING"] = True
+        app.config["WTF_CSRF_ENABLED"] = False
+        self.client = app.test_client()
+
+    def test_app_css_served(self):
+        rv = self.client.get("/static/app.css")
+        self.assertEqual(rv.status_code, 200)
+        self.assertIn("text/css", rv.headers["Content-Type"])
+        # design token が含まれる (sanity check)
+        self.assertIn(b"--color-primary", rv.data)
+
+    def test_app_js_served(self):
+        rv = self.client.get("/static/app.js")
+        self.assertEqual(rv.status_code, 200)
+        # 重要 API 識別子が含まれる (Rev.4 の Critical 要素が抜けないことを保証)
+        for ident in (
+            b"data-poll-url",
+            b"data-swap-target",
+            b"setupPolls",
+            b"X-CSRFToken",
+            b"MutationObserver",
+            b"removedNodes",
+            b"_pollTimers",
+            b"document.hidden",
+        ):
+            self.assertIn(ident, rv.data, f"missing: {ident!r}")
+
+    def test_static_files_have_correct_mime(self):
+        rv = self.client.get("/static/app.css")
+        self.assertTrue(rv.headers["Content-Type"].startswith("text/css"))
+```
+
+`tests/test_dashboard_asset_version.py`:
+
+```python
+class TestAssetVersion(unittest.TestCase):
+    def test_default_asset_version_is_empty_string(self):
+        # default は空文字（PR I で git sha 等を入れる予定）
+        self.assertEqual(app.config.get("ASSET_VERSION", "MISSING"), "")
+
+    def test_asset_version_can_be_overridden(self):
+        # Plan review (Claude) #6: old が None でも復元で壊れないように pop ベースに
+        had_key = "ASSET_VERSION" in app.config
+        old = app.config.get("ASSET_VERSION")
+        try:
+            app.config["ASSET_VERSION"] = "abc123"
+            self.assertEqual(app.config["ASSET_VERSION"], "abc123")
+        finally:
+            if had_key:
+                app.config["ASSET_VERSION"] = old
+            else:
+                app.config.pop("ASSET_VERSION", None)
+```
+
+### 2. Green: 実装
+
+#### 2a. `bundle/dashboard/app.py` — ASSET_VERSION 注入
+
+```python
+# 既存 SECRET_KEY 設定の近くに
+app.config["ASSET_VERSION"] = os.environ.get("ASSET_VERSION", "")
+```
+
+`SECRET_KEY` と同じ env-driven パターンを採用。
+
+#### 2b. `bundle/dashboard/static/app.js` — pseudo-code 実体化
+
+Plan F の「コア API（pseudo-code、実装は PR G）」節をそのままコピーし、`buildIncludeQuery` と `swapInto` の helper も実装。
+
+ファイル冒頭にライセンス / 説明 comment 必要:
+
+```javascript
+/**
+ * agent-zoo dashboard — vanilla JS (Sprint 007 PR G)
+ *
+ * HTMX 互換の declarative API:
+ *   data-poll-url / data-poll-interval / data-swap-target / data-trigger-from
+ *   data-include / data-confirm / data-json-body / data-tab
+ *   data-bulk-action / data-bulk-select / data-bulk-target / data-suggest-target
+ *
+ * 設計の正本: docs/dev/adr/0004-dashboard-external-deps-removal.md
+ *           docs/plans/sprint-007-pr-f.md (pseudo-code)
+ */
+```
+
+#### 2c. `bundle/dashboard/static/app.css` — 自前 CSS
+
+設計順:
+
+1. `:root` 変数 (design tokens、9 変数)
+2. base reset (body / box-sizing)
+3. `.layout-container` (max-width breakpoints)
+4. typography (h1〜h5)
+5. `.card` (article 代替)
+6. table styling
+7. form / input / button (`.btn-sm` / `.btn-secondary` / `.btn-contrast` / `.btn-outline`)
+8. `.status-badge` + `.status-ALLOWED` / `.status-BLOCKED` 等の単独 selector
+9. tab nav (`[data-tab]` styling)
+10. spinner (aria-busy 代替)
+11. utility classes (display, gap, margin)
+
+300 行を超えないよう、汎用 utility は最小限に絞る。
+
+### 3. Refactor
+
+新規ファイルなので大きな refactor 無し。lint:
+- `app.css`: stylelint があれば run
+- `app.js`: 構文 check (`node -c app.js` 相当)
+
+### 4. テスト全 PASS 確認
+
+```bash
+make unit  # 既存 380+ 件 + 新規 5〜6 件
+```
+
+---
+
+## 既存テストへの影響
+
+| テスト | 影響 | 対応 |
+|---|---|---|
+| `tests/test_dashboard.py` | 無し | そのまま |
+| `tests/test_dashboard_csrf.py` | 無し | そのまま |
+| `tests/test_dashboard_security_headers.py` | 無し | そのまま (CSP は PR I まで未変更) |
+| `tests/test_dashboard_domain_validation.py` | 無し | そのまま |
+| `tests/e2e/test_dashboard.py` | 無し（CDN htmx は引き続き動作、自前 JS は link 無し） | そのまま |
+
+---
+
+## Risk register
+
+| リスク | 軽減策 |
+|---|---|
+| 自前 JS のロジックバグが PR H link で発覚 | 単体 test で `data-poll-url` 含むか / `setupPolls` 関数が存在するか等の構文 sanity check |
+| CSS が後で template 書換時に過不足 | PR H で逐次 partial 単位に確認、必要なら CSS 追加 commit |
+| `app.config["ASSET_VERSION"] = ""` で `?v=` query が空 | 初回 cache miss 1 回のみ、運用上問題無し (Gemini レビュー Low 確認済) |
+| Flask static serving の MIME type が ブラウザで CSS/JS と認識されないリスク | test で Content-Type を assert |
+
+---
+
+## 受入基準
+
+- [ ] `bundle/dashboard/static/app.css` 新設、design tokens 9 変数 + layout + components で ~300 行以内
+- [ ] `bundle/dashboard/static/app.js` 新設、Plan F pseudo-code を実体化、**~200〜260 行 (コメント・IIFE・defensive 込)**
+- [ ] `bundle/dashboard/app.py` に `ASSET_VERSION` env 注入
+- [ ] `tests/test_dashboard_static.py` 新規 3 件 PASS
+- [ ] `tests/test_dashboard_asset_version.py` 新規 2 件 PASS
+- [ ] 既存 380+ unit + e2e 全 PASS（影響無し前提）
+- [ ] index.html は **未変更**（CDN htmx のままで動作継続を確認）
+
+---
+
+## Rev.3 self-review 反映 (Low/Medium 補注)
+
+| # | Sev | 指摘 | 反映 |
+|---|---|---|---|
+| I1 | Low | Plan F pseudo-code に登場する `data-bulk-scope` が data-* スキーマ表 (Plan F L179-194) に未記載 | Plan F (PR H 着手前) に追記、または data-* 表は ADR の data-* 設計原則の中で「補助属性」として注記 |
+| I2 | Low | JS line 240 行は Rev.2 の 120〜150 見積を超過 | 受入基準を 200〜260 行に緩和、実態は 165 行 logic + 50 行コメント + 20 行 defensive。コメントは仕様正本 link を保つため削除しない |
+| I3 | Medium | form submit / bulk action で fetch 失敗時 `swapInto` 非呼出 → swap 先が古い状態で残る | **PR H で検討**: `<small class="text-danger">エラー</small>` 等の error swap UI 追加、または `_pollTimers` のような retry 仕組み |
+| I4 | Low | IIFE wrap によるグローバル汚染ゼロ + デバッグ容易性のトレードオフ | **PR H 以降で検討**: `if (window.__DEBUG__) window.__dashboard = {...};` の opt-in expose 機構 |
+
+## Rev.3 Gemini 実装レビュー反映
+
+| # | Sev | 指摘 | 反映 |
+|---|---|---|---|
+| G-G1 | Medium | `form.method || 'POST'` は **常に form.method 採用** (HTML form の method property は未指定時 'get' 返却で truthy)。POST fallback が効かない | **本 PR で fix**: `form.getAttribute('method') || 'POST'` に変更 (`null` で fallback 効く)。コメントで意図明記 |
+| G-G2 | Medium | HTTP 401/403/404 時 backoff で再試行継続 → 無駄な負荷 | **PR H で検討**: 4xx (特に 401/403/404) を non-recoverable として polling 即停止、ユーザーに reload 促す |
+| G-G3 | Medium | XSS / a11y: `innerHTML` swap は server エスケープに依存、`aria-live="polite"` 未配置 | **PR H で検討**: server 側エスケープは既に Jinja autoescape で対応、a11y 対応 (aria-live / aria-selected) は PR H で template 書換と同時 |
+| G-G4 | Low | `console.warn` を URL constructor 失敗時にも出すと debug 容易 | 任意の改善、本 PR では skip (silent skip が UX 妥当) |
+| G-G5 | Low | bulk action の `alert()` がメインスレッドブロック | 将来 toast UI に置換 (PR H 以降の UX 改善 follow-up) |
+| G-G6 | Low | MutationObserver `subtree:true` は dashboard 規模で OK だが、PR H 後の 5s 周期再描画で `#main-content` 等に observe 範囲を限定する余地 | PR H で計測後に判断、本 PR では `document.body` のまま |
+
+## 参照
+
+- ADR 0004 (設計の正本): `docs/dev/adr/0004-dashboard-external-deps-removal.md`
+- Plan F (pseudo-code 正本 + レビュー履歴): `docs/plans/sprint-007-pr-f.md`

--- a/tests/test_dashboard_asset_version.py
+++ b/tests/test_dashboard_asset_version.py
@@ -1,0 +1,39 @@
+"""Sprint 007 PR G: dashboard `ASSET_VERSION` config の default テスト。
+
+ADR 0004 (Dashboard 外部依存ゼロ化) の cache busting 設計。
+PR H で template に `?v={{ asset_version }}` を埋め込むため、
+default が `""` (空文字) で Jinja UndefinedError を起こさないことを保証する。
+"""
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "bundle", "dashboard"))
+
+from app import app
+
+
+class TestAssetVersion(unittest.TestCase):
+    def test_default_asset_version_is_empty_string(self) -> None:
+        """env 未設定時、`ASSET_VERSION` config は空文字。"""
+        # SECRET_KEY と同様の env-driven pattern を採用。
+        # default は空文字、PR I で git short sha 等を入れる。
+        self.assertEqual(app.config.get("ASSET_VERSION", "MISSING"), "")
+
+    def test_asset_version_can_be_overridden(self) -> None:
+        """test 中の上書き → 復元が壊れない (Plan review #6: pop ベース復元)。"""
+        had_key = "ASSET_VERSION" in app.config
+        old = app.config.get("ASSET_VERSION")
+        try:
+            app.config["ASSET_VERSION"] = "abc123"
+            self.assertEqual(app.config["ASSET_VERSION"], "abc123")
+        finally:
+            if had_key:
+                app.config["ASSET_VERSION"] = old
+            else:
+                app.config.pop("ASSET_VERSION", None)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_dashboard_static.py
+++ b/tests/test_dashboard_static.py
@@ -1,0 +1,64 @@
+"""Sprint 007 PR G: dashboard 自前 static (CSS / JS) の Flask 配信テスト。
+
+ADR 0004 (Dashboard 外部依存ゼロ化) の基盤レイヤー。
+template への link 追加は PR H で行う。本テストは「ファイルが配信される」
+「pseudo-code Critical 要素が抜けていない」を保証する。
+"""
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "bundle", "dashboard"))
+
+from app import app
+
+
+class TestStaticAssets(unittest.TestCase):
+    def setUp(self) -> None:
+        app.config["TESTING"] = True
+        app.config["WTF_CSRF_ENABLED"] = False
+        self.client = app.test_client()
+
+    def test_app_css_served(self) -> None:
+        """`/static/app.css` が 200 + text/css MIME で配信される。"""
+        rv = self.client.get("/static/app.css")
+        self.assertEqual(rv.status_code, 200)
+        self.assertTrue(
+            rv.headers["Content-Type"].startswith("text/css"),
+            rv.headers["Content-Type"],
+        )
+        # design token が含まれる sanity check
+        self.assertIn(b"--color-primary", rv.data)
+        self.assertIn(b"--color-text", rv.data)
+        self.assertIn(b"--badge-blocked-bg", rv.data)
+        self.assertIn(b".layout-container", rv.data)
+        self.assertIn(b".status-BLOCKED", rv.data)
+
+    def test_app_js_served(self) -> None:
+        """`/static/app.js` が 200 で配信され、Rev.4 Critical 要素が抜けていない。"""
+        rv = self.client.get("/static/app.js")
+        self.assertEqual(rv.status_code, 200)
+        # Plan review (Claude) #1: pseudo-code Critical 要素が抜け落ちた状態で
+        # merge されないよう、識別子の含有を assert する。
+        for ident in (
+            b"data-poll-url",
+            b"data-swap-target",
+            b"setupPolls",
+            b"X-CSRFToken",
+            b"MutationObserver",
+            b"removedNodes",
+            b"_pollTimers",
+            b"document.hidden",
+        ):
+            self.assertIn(ident, rv.data, f"missing required identifier: {ident!r}")
+
+    def test_app_js_csrf_helper_reads_meta_each_call(self) -> None:
+        """Gemini レビュー G1: CSRF token を毎回 meta から読む実装が含まれる。"""
+        rv = self.client.get("/static/app.js")
+        # `csrf` 関数 + `meta[name="csrf-token"]` の参照が source に存在
+        self.assertIn(b'meta[name="csrf-token"]', rv.data)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

ADR 0004 に基づき、dashboard の **自前実装ファイルを基盤として追加**。
template への link 追加 (CDN htmx/pico の置換) は **PR H** で行う。本 PR の段階では index.html は CDN htmx を引き続き使用、自前 JS は未 link で動作影響なし。

## 変更ファイル

| ファイル | 内容 | 行数 |
|---|---|---|
| `bundle/dashboard/app.py` | `ASSET_VERSION` env 注入 (default 空文字) | +5 |
| `bundle/dashboard/static/app.css` | 自前 CSS (design tokens / layout / status badge / tab nav / utility) | +284 |
| `bundle/dashboard/static/app.js` | vanilla JS (Plan F Rev.4 pseudo-code 実体化) | +240 |
| `tests/test_dashboard_static.py` | /static/* の 200 + Critical API 識別子含有 | +3 ケース |
| `tests/test_dashboard_asset_version.py` | config default + override | +2 ケース |
| `docs/plans/sprint-007-pr-g.md` | PR G の Plan doc (Rev.3) | +201 |

## 主要な実装判断

| 項目 | 内容 |
|---|---|
| design tokens | `:root` にフラット定義 (将来 dark theme で `@media (prefers-color-scheme: dark)` で同名変数を上書き可能) |
| status badge | `.status-BLOCKED` 単独 selector で badge と数値強調の二役 (`.stat-card h2.status-BLOCKED` で specificity 上書き) |
| polling | exponential backoff (`base × 2^failures`、最大 60s)、`document.hidden` で skip、defensive guard (isNaN / pollUrl 欠落) |
| MutationObserver | `addedNodes` で setupPolls、**`removedNodes` で自身+子孫を clearInterval** (Plan F Gemini G2 反映) |
| CSRF token | 毎 fetch 取得 (`<meta name=\"csrf-token\">` rotation 対応) |
| `form.method` bug fix | `form.method || 'POST'` は HTML 未指定時 `'get'` 返却で truthy → POST fallback 効かず。`form.getAttribute('method') || 'POST'` に変更 (Gemini レビュー G-G1) |
| IIFE wrap | グローバル汚染ゼロ + 'use strict' で安全網 |

## レビュー履歴

- **Plan G Rev.1 → Rev.2**: Plan review (Claude subagent + Gemini 並行) で High 0 / Medium 4 / Low 3
- **Plan G Rev.3**: 実装 self-review (Claude subagent) で Low 4 + Gemini 再レビュー Medium 1 / Low 5
- 主要 fix: `form.getAttribute('method')` への変更で POST fallback bug 解消

## テスト結果

- 新規 5 件 PASS
- 既存 380+ → **391 件 PASS** (regression なし)
- E2E は本 PR scope 外 (template 未変更、CDN htmx 動作継続)

## 次の PR

- **PR H**: index.html / partials の \`hx-*\` → \`data-*\` + 自前 class への完全置換 (~500 行)、E2E selector 追従、inline assets test 追加
- **PR I**: CDN link 削除、CSP \`'self'\` 厳格化、E2E オフライン動作確認

## Test plan

- [x] \`uv run pytest tests/ --ignore=tests/e2e\` 全 PASS (391 件)
- [x] \`/static/app.css\` 配信、design token 含有
- [x] \`/static/app.js\` 配信、Critical API 識別子全件含有
- [x] \`ASSET_VERSION\` config default が \"\"
- [ ] (PR H で) E2E P1 で template 書換後の動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)