### PR TITLE
:recycle: Sprint 007 PR H: dashboard template を hx-* から data-* に全書換

### DIFF
--- a/bundle/dashboard/app.py
+++ b/bundle/dashboard/app.py
@@ -67,6 +67,13 @@ app.config["WTF_CSRF_HEADERS"] = ["X-CSRFToken", "X-CSRF-Token"]
 # default で Jinja UndefinedError を回避。PR I で git short sha 等の注入を検討。
 # `?v={{ asset_version }}` を template 側で defensive に出すパターンが Plan G review G3。
 app.config["ASSET_VERSION"] = os.environ.get("ASSET_VERSION", "")
+
+
+# Sprint 007 PR H (self-review H-1): app.config だけでは Jinja `asset_version` 変数は
+# 参照できない。context_processor で全 render_template に inject する。
+@app.context_processor
+def _inject_asset_version() -> dict:
+    return {"asset_version": app.config.get("ASSET_VERSION", "")}
 # Flask-WTF 1.2.x は TESTING=True でも CSRF を自動無効化しない。既存 test は setUp で
 # `app.config["WTF_CSRF_ENABLED"] = False` を明示指定している。CSRF 動作検証は
 # test_dashboard_csrf.py で WTF_CSRF_ENABLED=True にして実施。

--- a/bundle/dashboard/static/app.js
+++ b/bundle/dashboard/static/app.js
@@ -93,19 +93,40 @@
     nodes.forEach((el) => {
       if (_pollTimers.has(el)) return;
       let baseInterval = parseInt(el.dataset.pollInterval || '5000', 10);
-      if (isNaN(baseInterval) || baseInterval <= 0) baseInterval = 5000;
+      // baseInterval = 0 → 「load only」(HTMX hx-trigger="load" 互換)
+      // 負値 / NaN → 5000 ms に fallback
+      if (isNaN(baseInterval) || baseInterval < 0) baseInterval = 5000;
       _pollTimers.set(el, { intervalId: 0, failures: 0, baseInterval });
       pollOnce(el); // 即時
-      _scheduleInterval(el, baseInterval);
+      if (baseInterval > 0) {
+        _scheduleInterval(el, baseInterval);
+      }
 
       if (el.dataset.triggerFrom) {
+        // Plan H レビュー M5: 同 selector + event の listener を 1 度だけ attach。
+        // 重複 attach すると MutationObserver で setupPolls 再呼出時に
+        // listener 数が N→2N→4N と倍増する。
         const [sel, ev] = el.dataset.triggerFrom.split(':');
-        document.body.addEventListener(ev || 'change', (e) => {
-          if (e.target.closest && e.target.closest(sel)) pollOnce(el);
-        });
+        const evName = ev || 'change';
+        const key = evName + ':' + sel;
+        let bucket = _triggerListenersByTarget.get(key);
+        if (!bucket) {
+          bucket = new Set();
+          _triggerListenersByTarget.set(key, bucket);
+          document.body.addEventListener(evName, (e) => {
+            if (!(e.target.closest && e.target.closest(sel))) return;
+            // bucket 内の全 polling element に通知 (多対 1 trigger をサポート)
+            bucket.forEach((targetEl) => pollOnce(targetEl));
+          });
+        }
+        bucket.add(el);
       }
     });
   }
+
+  // Plan H レビュー M5: triggerFrom の重複 attach 防止用 registry。
+  // key = "{event}:{selector}", value = Set<polling element>
+  const _triggerListenersByTarget = new Map();
 
   // === Form submit (data-swap-target) ===
   document.body.addEventListener('submit', async (ev) => {
@@ -145,10 +166,28 @@
     });
     const target = document.getElementById('tab-' + name);
     if (target) target.classList.remove('hidden');
-    document
-      .querySelectorAll('[data-tab]')
-      .forEach((a) => a.classList.remove('active'));
+    // Plan H L8: a11y、aria-selected を更新
+    document.querySelectorAll('[data-tab]').forEach((a) => {
+      a.classList.remove('active');
+      a.setAttribute('aria-selected', 'false');
+    });
     tab.classList.add('active');
+    tab.setAttribute('aria-selected', 'true');
+  });
+
+  // === Bulk toggle-all (data-bulk-toggle-all): 全選択 checkbox の delegation ===
+  // Plan H H2: PR G では実装漏れだった toggleAllInbox 代替。
+  // change event で [data-bulk-toggle-all] の checked 状態を
+  // data-bulk-toggle-scope (selector) 内の [data-bulk-select] に伝播する。
+  document.body.addEventListener('change', (ev) => {
+    const master = ev.target.closest && ev.target.closest('[data-bulk-toggle-all]');
+    if (!master) return;
+    const scopeSel = master.dataset.bulkToggleScope;
+    const scope = scopeSel ? document.querySelector(scopeSel) : document;
+    if (!scope) return;
+    scope
+      .querySelectorAll('[data-bulk-select]')
+      .forEach((cb) => { cb.checked = master.checked; });
   });
 
   // === Bulk action (data-bulk-action) ===

--- a/bundle/dashboard/templates/index.html
+++ b/bundle/dashboard/templates/index.html
@@ -3,41 +3,27 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <!-- CSRF token (H-1): HTMX と fetch() でヘッダ送出、bulk 等の inline JS は meta から読む -->
+    {# CSRF token (H-1): app.js の csrf() helper が毎 fetch ごとに meta から読む。
+       PR H 以降は <meta> を head から削除しないこと (Plan F G1 / Plan H 受入基準)。 #}
     <meta name="csrf-token" content="{{ csrf_token() }}">
     <title>Agent Harness Dashboard</title>
+    {# CDN pico/htmx は Sprint 007 PR I で削除予定。本 PR (H) では並存させ、
+       自前 CSS が後勝ちで上書きする (link 順序が後)。 #}
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.min.css">
+    {# 自前 CSS / JS。{% if asset_version %} で空時 query 省略 (Plan G G3 defensive)。 #}
+    <link rel="stylesheet" href="/static/app.css{% if asset_version %}?v={{ asset_version }}{% endif %}">
     <script src="https://unpkg.com/htmx.org@2.0.4"></script>
-    <style>
-        :root { --pico-font-size: 14px; }
-        .stat-grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 1rem; margin-bottom: 1.5rem; }
-        .stat-card { text-align: center; padding: 1rem; }
-        .stat-card h2 { margin: 0; font-size: 2rem; }
-        .stat-card small { color: var(--pico-muted-color); }
-        .status-badge { padding: 2px 8px; border-radius: 4px; font-size: 0.75rem; font-weight: 600; }
-        .status-ALLOWED { background: #d4edda; color: #155724; }
-        .status-BLOCKED, .status-PAYLOAD_BLOCKED { background: #f8d7da; color: #721c24; }
-        .status-RATE_LIMITED { background: #fff3cd; color: #856404; }
-        table { font-size: 0.85rem; }
-        nav h1 { margin: 0; }
-        .btn-sm { padding: 0.25rem 0.5rem !important; font-size: 0.75rem !important; margin: 0 0.15rem !important; cursor: pointer; width: auto !important; display: inline-block !important; }
-        table form { display: inline !important; margin: 0 !important; width: auto !important; }
-        table input[type="text"] { width: 120px !important; margin: 0 !important; padding: 0.2rem 0.4rem !important; font-size: 0.75rem !important; display: inline-block !important; }
-        .tab-nav { display: flex; gap: 0; margin-bottom: 1.5rem; }
-        .tab-nav a { padding: 0.5rem 1.5rem; border-bottom: 2px solid transparent; text-decoration: none; color: var(--pico-muted-color); }
-        .tab-nav a.active { border-bottom-color: var(--pico-primary); color: var(--pico-color); }
-        .badge { background: var(--pico-del-color); color: white; padding: 0.1rem 0.4rem; border-radius: 4px; font-size: 0.7rem; margin-left: 0.3rem; }
-    </style>
+    <script defer src="/static/app.js{% if asset_version %}?v={{ asset_version }}{% endif %}"></script>
 </head>
-<body hx-headers='{"X-CSRFToken": "{{ csrf_token() }}"}'>
-    <nav class="container">
-        <ul><li><h1>Agent Zoo</h1></li></ul>
-        <ul><li><small>Dashboard</small></li></ul>
+<body>
+    <nav class="layout-container app-nav">
+        <h1>Agent Zoo</h1>
+        <small>Dashboard</small>
     </nav>
 
-    <main class="container">
+    <main class="layout-container">
         <!-- Stats -->
-        <div hx-get="/partials/stats" hx-trigger="load, every 5s" hx-swap="innerHTML">
+        <div data-poll-url="/partials/stats" data-poll-interval="5000" aria-live="polite">
             <div class="stat-grid">
                 <article class="stat-card"><h2>-</h2><small>Total</small></article>
                 <article class="stat-card"><h2>-</h2><small>Blocked</small></article>
@@ -47,61 +33,55 @@
         </div>
 
         <!-- Tabs -->
-        <div class="tab-nav" id="tabs">
-            <a href="#" class="active" onclick="showTab('requests', this)">Requests</a>
-            <a href="#" onclick="showTab('tool-uses', this)">Tool Uses</a>
-            <a href="#" onclick="showTab('inbox', this)">Inbox</a>
-            <a href="#" onclick="showTab('whitelist', this)">Whitelist</a>
+        <div class="tab-nav" role="tablist" id="tabs">
+            <a href="#" id="tabnav-requests" class="active" role="tab" aria-selected="true" aria-controls="tab-requests" data-tab="requests">Requests</a>
+            <a href="#" id="tabnav-tool-uses" role="tab" aria-selected="false" aria-controls="tab-tool-uses" data-tab="tool-uses">Tool Uses</a>
+            <a href="#" id="tabnav-inbox" role="tab" aria-selected="false" aria-controls="tab-inbox" data-tab="inbox">Inbox</a>
+            <a href="#" id="tabnav-whitelist" role="tab" aria-selected="false" aria-controls="tab-whitelist" data-tab="whitelist">Whitelist</a>
         </div>
 
         <!-- Requests Tab -->
-        <div id="tab-requests">
-            <form id="requests-filter-form" style="display:flex;gap:0.5rem;margin-bottom:0.5rem;align-items:center"
-                hx-get="/partials/requests" hx-target="#requests-container" hx-swap="innerHTML"
-                hx-trigger="change from:#status-filter, load, every 5s" hx-include="#status-filter">
+        <div id="tab-requests" role="tabpanel" aria-labelledby="tabnav-requests">
+            <div class="flex gap-2 items-center mb-2">
                 <small>Filter:</small>
-                <select id="status-filter" name="status" style="padding:0.2rem 0.5rem;font-size:0.8rem;width:auto;margin:0">
+                <select id="status-filter" name="status">
                     <option value="">All</option>
                     <option value="ALLOWED">ALLOWED</option>
                     <option value="BLOCKED">BLOCKED</option>
                     <option value="RATE_LIMITED">RATE_LIMITED</option>
                     <option value="PAYLOAD_BLOCKED">PAYLOAD_BLOCKED</option>
                 </select>
-            </form>
-            <div id="requests-container">
-                <p aria-busy="true">Loading...</p>
+            </div>
+            <div id="requests-container"
+                data-poll-url="/partials/requests"
+                data-poll-interval="5000"
+                data-trigger-from="#status-filter:change"
+                data-include="#status-filter"
+                aria-live="polite">
+                <p>Loading...</p>
             </div>
         </div>
 
         <!-- Tool Uses Tab -->
-        <div id="tab-tool-uses" style="display:none">
-            <div hx-get="/partials/tool-uses" hx-trigger="load, every 5s" hx-swap="innerHTML">
-                <p aria-busy="true">Loading...</p>
+        <div id="tab-tool-uses" role="tabpanel" aria-labelledby="tabnav-tool-uses" class="hidden">
+            <div data-poll-url="/partials/tool-uses" data-poll-interval="5000" aria-live="polite">
+                <p>Loading...</p>
             </div>
         </div>
 
         <!-- Inbox Tab (ADR 0001 A-6) -->
-        <div id="tab-inbox" style="display:none">
-            <div hx-get="/partials/inbox" hx-trigger="load" hx-swap="innerHTML">
-                <p aria-busy="true">Loading...</p>
+        <div id="tab-inbox" role="tabpanel" aria-labelledby="tabnav-inbox" class="hidden">
+            <div data-poll-url="/partials/inbox" data-poll-interval="0" aria-live="polite">
+                <p>Loading...</p>
             </div>
         </div>
 
         <!-- Whitelist Tab -->
-        <div id="tab-whitelist" style="display:none">
-            <div hx-get="/partials/whitelist" hx-trigger="load" hx-swap="innerHTML">
-                <p aria-busy="true">Loading...</p>
+        <div id="tab-whitelist" role="tabpanel" aria-labelledby="tabnav-whitelist" class="hidden">
+            <div data-poll-url="/partials/whitelist" data-poll-interval="0" aria-live="polite">
+                <p>Loading...</p>
             </div>
         </div>
     </main>
-
-    <script>
-    function showTab(name, el) {
-        document.querySelectorAll('[id^="tab-"]').forEach(t => t.style.display = 'none');
-        document.getElementById('tab-' + name).style.display = '';
-        document.querySelectorAll('.tab-nav a').forEach(a => a.classList.remove('active'));
-        el.classList.add('active');
-    }
-    </script>
 </body>
 </html>

--- a/bundle/dashboard/templates/partials/inbox.html
+++ b/bundle/dashboard/templates/partials/inbox.html
@@ -2,15 +2,26 @@
 <p><small>エージェントが提出した未承認のリクエスト（ADR 0001）。許可するとそのまま <code>policy.runtime.toml</code> に反映されます。</small></p>
 
 {% if items %}
-<div style="display:flex;gap:0.5rem;margin-bottom:0.5rem">
-    <button type="button" class="btn-sm" onclick="bulkInbox('/api/inbox/bulk-accept', '選択を一括許可しますか？')">選択を一括許可</button>
-    <button type="button" class="btn-sm secondary" onclick="bulkInbox('/api/inbox/bulk-reject', '選択を一括却下しますか？')">選択を一括却下</button>
+{# data-bulk-scope は bulk button と table を同 element で囲み、btn.closest('[data-bulk-scope]')
+   が table 内の [data-bulk-select] にアクセスできるようにする (Plan H 実装注記)。 #}
+<div data-bulk-scope="inbox">
+<div class="flex gap-2 mb-2">
+    <button type="button" class="btn-sm"
+        data-bulk-action="/api/inbox/bulk-accept"
+        data-bulk-target="#tab-inbox"
+        data-bulk-confirm="選択を一括許可しますか？">選択を一括許可</button>
+    <button type="button" class="btn-sm btn-secondary"
+        data-bulk-action="/api/inbox/bulk-reject"
+        data-bulk-target="#tab-inbox"
+        data-bulk-confirm="選択を一括却下しますか？">選択を一括却下</button>
 </div>
 
-<table style="font-size:0.85rem">
+<table>
     <thead>
         <tr>
-            <th><input type="checkbox" id="inbox-select-all" onclick="toggleAllInbox(this)"></th>
+            <th><input type="checkbox" id="inbox-select-all"
+                data-bulk-toggle-all
+                data-bulk-toggle-scope="[data-bulk-scope='inbox']"></th>
             <th>Action</th>
             <th>Type</th>
             <th>Value</th>
@@ -22,19 +33,20 @@
     <tbody>
     {% for r in items %}
     <tr>
-        <td><input type="checkbox" class="inbox-cb" value="{{ r._id }}"></td>
-        <td style="white-space:nowrap">
-            {# H-4: hx-vals は |tojson|forceescape で JSON-safe な literal にし
-               record_id 内の特殊文字による属性 injection / XSS を防ぐ。 #}
-            <form style="display:inline;margin:0" hx-post="/api/inbox/accept" hx-target="#tab-inbox" hx-swap="innerHTML"
-                hx-confirm="このリクエストを許可しますか？" hx-ext="json-enc"
-                hx-vals="{{ {'record_id': r._id}|tojson|forceescape }}">
+        <td><input type="checkbox" class="bulk-cb" data-bulk-select value="{{ r._id }}"></td>
+        <td class="nowrap">
+            {# Plan H H1: data-json-body は |tojson|forceescape で JSON-safe な literal にし
+               record_id 内の特殊文字による attribute injection / XSS を防ぐ。 #}
+            <form action="/api/inbox/accept" method="POST"
+                data-swap-target="#tab-inbox"
+                data-confirm="このリクエストを許可しますか？"
+                data-json-body="{{ {'record_id': r._id}|tojson|forceescape }}">
                 <button type="submit" class="btn-sm">許可</button>
             </form>
-            <form style="display:inline;margin:0" hx-post="/api/inbox/reject" hx-target="#tab-inbox" hx-swap="innerHTML"
-                hx-ext="json-enc"
-                hx-vals="{{ {'record_id': r._id}|tojson|forceescape }}">
-                <button type="submit" class="btn-sm secondary">却下</button>
+            <form action="/api/inbox/reject" method="POST"
+                data-swap-target="#tab-inbox"
+                data-json-body="{{ {'record_id': r._id}|tojson|forceescape }}">
+                <button type="submit" class="btn-sm btn-secondary">却下</button>
             </form>
         </td>
         <td><strong>{{ r.type }}</strong></td>
@@ -45,37 +57,14 @@
             <code>{{ r.value }}</code>
             {% endif %}
         </td>
-        <td style="font-size:0.75rem;max-width:300px"><small>{{ r.reason }}</small></td>
+        <td class="fs-sm path-cell"><small>{{ r.reason }}</small></td>
         <td><small>{{ r.agent }}</small></td>
         <td><small>{{ r.created_at }}</small></td>
     </tr>
     {% endfor %}
     </tbody>
 </table>
-
-<script>
-function toggleAllInbox(master) {
-    document.querySelectorAll('.inbox-cb').forEach(cb => cb.checked = master.checked);
-}
-function bulkInbox(url, confirmMsg) {
-    var ids = Array.from(document.querySelectorAll('.inbox-cb:checked')).map(cb => cb.value);
-    if (ids.length === 0) { alert('選択してください'); return; }
-    if (!confirm(confirmMsg)) return;
-    var csrfMeta = document.querySelector('meta[name="csrf-token"]');
-    var csrfToken = csrfMeta ? csrfMeta.content : '';
-    fetch(url, {
-        method: 'POST',
-        headers: {
-            'Content-Type': 'application/json',
-            'HX-Request': 'true',
-            'X-CSRFToken': csrfToken
-        },
-        body: JSON.stringify({record_ids: ids})
-    }).then(r => r.text()).then(html => {
-        document.getElementById('tab-inbox').innerHTML = html;
-    });
-}
-</script>
+</div>
 {% else %}
 <p><small>未承認のリクエストはありません。</small></p>
 {% endif %}

--- a/bundle/dashboard/templates/partials/requests.html
+++ b/bundle/dashboard/templates/partials/requests.html
@@ -14,7 +14,7 @@
         <tr>
             <td>{{ row.ts }}</td>
             <td>{{ row.host }}</td>
-            <td style="max-width:400px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;font-family:monospace;font-size:0.8rem" title="{{ row.url }}">{{ row.path }}</td>
+            <td class="path-cell" title="{{ row.url }}">{{ row.path }}</td>
             <td>{{ row.method }}</td>
             <td><span class="status-badge status-{{ row.status }}">{{ row.status }}</span></td>
             <td>{{ row.body_size }}</td>

--- a/bundle/dashboard/templates/partials/tool-uses.html
+++ b/bundle/dashboard/templates/partials/tool-uses.html
@@ -12,7 +12,7 @@
         <tr>
             <td>{{ row.ts }}</td>
             <td><strong>{{ row.tool_name }}</strong></td>
-            <td style="max-width:400px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap" title="{{ row.input }}">{{ row.input }}</td>
+            <td class="path-cell" title="{{ row.input }}">{{ row.input }}</td>
             <td>{{ row.input_size }}</td>
         </tr>
         {% endfor %}

--- a/bundle/dashboard/templates/partials/whitelist.html
+++ b/bundle/dashboard/templates/partials/whitelist.html
@@ -1,20 +1,22 @@
 <!-- 現在のポリシー設定 -->
 <h4>Current Policy</h4>
 
-<h5 style="margin-bottom:0.5rem">Domain Rules</h5>
-<table style="font-size:0.85rem">
+<h5 class="mb-2">Domain Rules</h5>
+<table>
     <thead><tr><th>Type</th><th>Domains</th><th></th></tr></thead>
     <tbody>
         <tr>
-            <td><span style="color:var(--pico-ins-color)">Allow</span></td>
+            <td><span class="text-success">Allow</span></td>
             <td>
                 {% for d in current_policy.base_allow_domains %}<code>{{ d }}</code> {% endfor %}
                 {% for d in current_policy.runtime_allow_domains %}
-                <code style="border:1px solid var(--pico-primary)">{{ d }}</code>
-                <form style="display:inline;margin:0" hx-post="/api/whitelist/revoke-domain" hx-target="#tab-whitelist" hx-swap="innerHTML"
-                    hx-confirm="{{ d }} の許可を取り消しますか？">
+                <code class="runtime-marker">{{ d }}</code>
+                <form action="/api/whitelist/revoke-domain" method="POST"
+                    data-swap-target="#tab-whitelist"
+                    data-confirm="{{ d }} の許可を取り消しますか？"
+                    class="form-inline">
                     <input type="hidden" name="domain" value="{{ d }}">
-                    <button type="submit" class="btn-sm" style="color:var(--pico-del-color);font-size:0.65rem;padding:1px 4px">✕</button>
+                    <button type="submit" class="btn-sm btn-danger-text">✕</button>
                 </form>
                 {% endfor %}
                 {% if not current_policy.base_allow_domains and not current_policy.runtime_allow_domains %}<small>なし</small>{% endif %}
@@ -22,24 +24,24 @@
             <td></td>
         </tr>
         <tr>
-            <td><span style="color:var(--pico-del-color)">Deny</span></td>
+            <td><span class="text-danger">Deny</span></td>
             <td>{% for d in current_policy.deny_domains %}<code>{{ d }}</code> {% endfor %}{% if not current_policy.deny_domains %}<small>なし</small>{% endif %}</td>
             <td></td>
         </tr>
     </tbody>
 </table>
 
-<h5 style="margin-bottom:0.5rem">Path Rules</h5>
+<h5 class="mb-2">Path Rules</h5>
 {% set has_paths = current_policy.base_paths_allow or current_policy.runtime_paths_allow %}
 {% if has_paths %}
-<table style="font-size:0.8rem">
-    <thead><tr><th>Domain</th><th style="color:var(--pico-ins-color)">Allowed Paths</th><th></th></tr></thead>
+<table>
+    <thead><tr><th>Domain</th><th class="text-success">Allowed Paths</th><th></th></tr></thead>
     <tbody>
     {% for domain, patterns in current_policy.base_paths_allow.items() %}
     <tr>
         <td>{{ domain }}</td>
         <td>{% for p in patterns %}<code>{{ p }}</code> {% endfor %}</td>
-        <td><small style="color:var(--pico-muted-color)">base</small></td>
+        <td><small class="text-base-policy">base</small></td>
     </tr>
     {% endfor %}
     {% for domain, patterns in current_policy.runtime_paths_allow.items() %}
@@ -47,16 +49,18 @@
         <td>{{ domain }}</td>
         <td>
             {% for p in patterns %}
-            <code style="border:1px solid var(--pico-primary)">{{ p }}</code>
-            <form style="display:inline-block;margin:0;width:auto" hx-post="/api/whitelist/revoke-path" hx-target="#tab-whitelist" hx-swap="innerHTML"
-                hx-confirm="パスルールを削除しますか？">
+            <code class="runtime-marker">{{ p }}</code>
+            <form action="/api/whitelist/revoke-path" method="POST"
+                data-swap-target="#tab-whitelist"
+                data-confirm="パスルールを削除しますか？"
+                class="form-inline">
                 <input type="hidden" name="domain" value="{{ domain }}">
                 <input type="hidden" name="path_pattern" value="{{ p }}">
-                <button type="submit" class="btn-sm" style="color:var(--pico-del-color);font-size:0.65rem;padding:1px 4px;margin:0;width:auto">✕</button>
+                <button type="submit" class="btn-sm btn-danger-text">✕</button>
             </form>
             {% endfor %}
         </td>
-        <td><small style="color:var(--pico-primary)">runtime</small></td>
+        <td><small class="text-runtime">runtime</small></td>
     </tr>
     {% endfor %}
     </tbody>
@@ -65,8 +69,8 @@
 <p><small>パスルールなし</small></p>
 {% endif %}
 {% if current_policy.paths_deny %}
-<table style="font-size:0.8rem">
-    <thead><tr><th>Domain</th><th style="color:var(--pico-del-color)">Denied Paths</th></tr></thead>
+<table>
+    <thead><tr><th>Domain</th><th class="text-danger">Denied Paths</th></tr></thead>
     <tbody>
     {% for domain, patterns in current_policy.paths_deny.items() %}
     <tr>
@@ -85,7 +89,7 @@
 <p><small>ブロックされたドメイン。アクションを選んでください。</small></p>
 
 {% if candidates %}
-<table style="font-size:0.85rem">
+<table>
     <thead>
         <tr>
             <th>Action</th>
@@ -98,63 +102,48 @@
     <tbody>
     {% for c in candidates %}
     <tr>
-        <td style="white-space:nowrap">
-            <form style="display:inline;margin:0" hx-post="/api/whitelist/allow" hx-target="#tab-whitelist" hx-swap="innerHTML"
-                hx-confirm="{{ c.host }} をドメインごと許可しますか？">
+        <td class="nowrap">
+            <form action="/api/whitelist/allow" method="POST"
+                data-swap-target="#tab-whitelist"
+                data-confirm="{{ c.host }} をドメインごと許可しますか？"
+                class="form-inline">
                 <input type="hidden" name="domain" value="{{ c.host }}">
                 <button type="submit" class="btn-sm">許可</button>
             </form>
-            <form style="display:inline;margin:0" hx-post="/api/whitelist/dismiss" hx-target="#tab-whitelist" hx-swap="innerHTML">
+            <form action="/api/whitelist/dismiss" method="POST"
+                data-swap-target="#tab-whitelist"
+                class="form-inline">
                 <input type="hidden" name="domain" value="{{ c.host }}">
                 <input type="hidden" name="reason" value="dashboard dismiss">
-                <button type="submit" class="btn-sm secondary">無視</button>
+                <button type="submit" class="btn-sm btn-secondary">無視</button>
             </form>
         </td>
         <td><strong>{{ c.host }}</strong></td>
         <td><span class="badge">{{ c.count }}</span></td>
-        <td style="font-size:0.75rem;max-width:250px">
+        <td class="path-cell">
             {% if c.paths %}
-            <ul style="margin:0;padding-left:1rem" class="url-suggest-list">
+            <ul class="url-suggest-list">
                 {% for url in c.paths %}
-                <li style="cursor:pointer;text-decoration:underline;word-break:break-all"
-                    data-url="{{ url }}"
-                    data-target="path-{{ c.host|replace('.', '-') }}"
+                <li data-url="{{ url }}"
+                    data-suggest-target="#path-{{ c.host|replace('.', '-') }}"
                     title="クリックでパスパターン入力">{{ url }}</li>
                 {% endfor %}
             </ul>
             {% endif %}
         </td>
-        <td style="white-space:nowrap">
-            <form style="display:flex;gap:0.2rem;align-items:center;margin:0"
-                hx-post="/api/whitelist/allow-path" hx-target="#tab-whitelist" hx-swap="innerHTML">
+        <td class="nowrap">
+            <form action="/api/whitelist/allow-path" method="POST"
+                data-swap-target="#tab-whitelist"
+                class="form-inline">
                 <input type="hidden" name="domain" value="{{ c.host }}">
-                <input type="text" name="path_pattern" id="path-{{ c.host|replace('.', '-') }}" placeholder="/path/*" value="/*"
-                    style="padding:0.2rem 0.4rem;font-size:0.75rem;width:120px;margin:0">
-                <button type="submit" class="btn-sm outline" style="white-space:nowrap">許可</button>
+                <input type="text" name="path_pattern" id="path-{{ c.host|replace('.', '-') }}" placeholder="/path/*" value="/*">
+                <button type="submit" class="btn-sm btn-outline">許可</button>
             </form>
         </td>
     </tr>
     {% endfor %}
     </tbody>
 </table>
-<script>
-(function() {
-    var items = document.querySelectorAll('.url-suggest-list li[data-url]');
-    items.forEach(function(li) {
-        li.addEventListener('click', function(e) {
-            e.stopPropagation();
-            e.preventDefault();
-            try {
-                var u = new URL(this.dataset.url);
-                var p = u.pathname;
-                var v = p.lastIndexOf('/') > 0 ? p.substring(0, p.lastIndexOf('/')) + '/*' : p + '*';
-                document.getElementById(this.dataset.target).value = v;
-                this.style.color = 'var(--pico-primary)';
-            } catch(ex) {}
-        });
-    });
-})();
-</script>
 {% else %}
 <p><small>候補なし</small></p>
 {% endif %}
@@ -176,9 +165,11 @@
             <td>{{ info.reason }}</td>
             <td>{{ info.date }}</td>
             <td>
-                <form style="display:inline;margin:0" hx-post="/api/whitelist/restore" hx-target="#tab-whitelist" hx-swap="innerHTML">
+                <form action="/api/whitelist/restore" method="POST"
+                    data-swap-target="#tab-whitelist"
+                    class="form-inline">
                     <input type="hidden" name="domain" value="{{ domain }}">
-                    <button type="submit" class="btn-sm contrast">Restore</button>
+                    <button type="submit" class="btn-sm btn-contrast">Restore</button>
                 </form>
             </td>
         </tr>

--- a/docs/plans/sprint-007-pr-h.md
+++ b/docs/plans/sprint-007-pr-h.md
@@ -1,0 +1,336 @@
+# Sprint 007 PR H: テンプレート書換え（メイン作業）
+
+| 項目 | 値 |
+|---|---|
+| 作成日 | 2026-04-19 |
+| 改訂 | Rev.3（self-review + Gemini 反映: cache busting 機能死 (context_processor 追加) + aria-labelledby 修正 / a11y 残課題は Sprint 008 follow-up に） |
+| Sprint | 007 |
+| PR | F (✅) → G (✅) → **H (本 PR)** → I |
+| 親設計 | [ADR 0004](../dev/adr/0004-dashboard-external-deps-removal.md) (Rev.4) |
+| 親計画 | [Plan F](sprint-007-pr-f.md) (Rev.4) — pseudo-code 正本 / [Plan G](sprint-007-pr-g.md) (Rev.3) |
+
+> ⚠ **Rev.2 重要追加**: Plan G レビューで見逃された `data-bulk-toggle-all` (全選択 checkbox) の delegation 実装が PR G app.js に **不在** であることが Plan H レビューで発覚。PR H では app.js への補正実装も含める。同時に triggerFrom listener の重複 attach bug も修正。
+
+---
+
+## ゴール
+
+Sprint 007 の **メイン作業**: dashboard の全 template (`index.html` + `partials/*.html`) を `hx-*` から `data-*` + 自前 class に完全書換し、自前 CSS/JS の link を **追加**（CDN htmx/pico は引き続き並存、PR I で削除）。
+
+### Deliverables
+
+1. **`bundle/dashboard/static/app.js` 補正**（PR G の漏れを修正、Rev.2 追加）
+   - **`data-bulk-toggle-all` delegation 追加**: change event で `[data-bulk-toggle-all]` の checked 状態を scope 内 `[data-bulk-select]` に伝播（`toggleAllInbox` 代替）
+   - **`data-bulk-scope` を `setupPolls` 系の補助属性として data-* スキーマに格上げ**: bulk button が table 全体を `data-bulk-scope` 親要素として参照する
+   - **triggerFrom listener の重複 attach bug 修正**: `_triggerListenersByTarget` Map で同 selector に対する listener を 1 回のみ attach する
+2. `bundle/dashboard/templates/index.html` 書換
+   - 自前 CSS/JS link 追加: **`{% if asset_version %}?v={{ asset_version }}{% endif %}` defensive 形式で全箇所統一**
+   - 既存 CDN link (pico/htmx) は **当面維持**（PR I で削除）
+   - **`<body hx-headers='{...}'>` の `hx-headers` 属性を削除**（CDN htmx に CSRF header 渡しを止める、自前 JS が `csrf()` で都度送出）
+   - inline `<style>`, `<script>`, `onclick=`, `style="..."` を **完全削除**
+   - `<meta name="csrf-token">` は `<head>` に **維持**（pseudo-code 必須要件）
+   - 4 polling div を `data-poll-url="/path"` + `data-poll-interval="5000"` に置換
+   - status-filter `<form>` を `<div id="requests-filter-form" data-poll-url="/partials/requests" data-poll-interval="5000" data-trigger-from="#status-filter:change" data-include="#status-filter" data-swap-target="#requests-container">` に変更（form タグは無くす、submit button が無く form の意味が無いため）
+   - tab nav `<a onclick="showTab('...')">` を `<a data-tab="..." href="#">` に置換
+   - **tab content 初期 hidden を `class="hidden"` で表現**（`style="display:none"` は削除、`.hidden { display: none; }` は PR G の app.css に既存）
+   - **アクセシビリティ補強（Plan G G3 follow-up）**: tab nav に `role="tablist"`、tab nav `<a>` に `role="tab"` + `aria-selected="true|false"`、tab content `<div>` に `role="tabpanel"` + `aria-labelledby` 付与。polling target に `aria-live="polite"` 付与
+3. `bundle/dashboard/templates/partials/inbox.html` 書換
+   - 各 form を `<form action="/api/inbox/{accept|reject}" method="POST" data-swap-target="#tab-inbox" data-confirm="..." data-json-body="{{ {'record_id': r._id}|tojson|forceescape }}">` に置換
+     - **重要**: `data-json-body` は **`{{ {'record_id': r._id}|tojson|forceescape }}` パターン**で属性値を生成（既存 hx-vals と同じ escape 戦略、attribute injection / XSS 防止）
+   - `<script>bulkInbox/toggleAllInbox</script>` 削除、bulk button を `<button type="button" data-bulk-action="/api/inbox/bulk-{accept|reject}" data-bulk-target="#tab-inbox" data-bulk-confirm="...">` に置換
+   - 全選択 checkbox を `<input type="checkbox" id="inbox-select-all" data-bulk-toggle-all data-bulk-toggle-scope="[data-bulk-scope='inbox']">` に置換（id 維持で e2e 互換）
+   - **table 全体を `<table data-bulk-scope="inbox">` で囲む**（または table の親 `<div>` に付与、bulk button もこの scope 内に配置）
+   - 個別 checkbox を `<input type="checkbox" class="bulk-cb" data-bulk-select value="{{ r._id }}">` に置換
+   - inline `style="..."` を class 化
+4. `bundle/dashboard/templates/partials/whitelist.html` 書換
+   - 各 form (allow / dismiss / restore / revoke / allow-path) を `<form action="/api/whitelist/..." method="POST" data-swap-target="#tab-whitelist" data-confirm="...">` に置換（hx-confirm 有り版のみ data-confirm 付与）
+   - URL suggest IIFE `<script>` 削除
+   - **既存 `<li data-url=... data-target="path-{{ host|replace('.', '-') }}" onclick=...>` を `<li class="url-suggest-item" data-url="{{ url }}" data-suggest-target="#path-{{ host|replace('.', '-') }}">` に rename**（`data-target` 完全削除、`#` prefix 追加、`onclick` 削除）
+   - inline `style="..."` を class 化（最も多い、~30 箇所）
+5. `bundle/dashboard/templates/partials/requests.html` / `stats.html` / `tool-uses.html` 書換
+   - inline `style="..."` を class 化（path-cell / status-badge は既存 PR G CSS で対応）
+6. `tests/test_dashboard_inline_assets.py` (新規) — BS4 ベースで `<script>` / `<style>` / `style=` / `onclick=` / `onsubmit=` 等不在を assert
+   - 全 6 endpoint (/, /partials/{stats,requests,tool-uses,inbox,whitelist}) で個別 assert
+   - csrf-token meta 存在
+   - 不要な `data-bulk-toggle-all` のような fixture 依存テストは本 PR では skip（fixture は別 PR）
+7. `tests/e2e/test_dashboard.py` selector 追従 — `form[hx-post*=]` → `form[action*=]` 等
+8. `docs/plans/sprint-007-pr-h.md`（本ファイル）
+
+### Non-goals
+
+- CDN link 削除（PR I）
+- CSP `'self'` 厳格化（PR I）
+- E2E オフライン動作確認（PR I）
+- dark theme 対応（Sprint 007 後の follow-up）
+- error UI swap（Plan G I3 で PR H 検討事項とした、本 PR で着手するか判断）
+
+---
+
+## 重要な設計原則（Plan F / Plan G から継承）
+
+1. **両持ち禁止**: PR H の commit 単位で `hx-*` と `data-*` を **同 form で並走させない**。CDN htmx と自前 JS が両方同 form を submit すると二重 POST する。partial 単位で「commit 1: hx-* 削除 + data-* 追加」を完結させる。
+2. **自前 JS link 追加は最後**: 各 partial の書換 commit が完了してから、index.html commit で `<script src=".../static/app.js">` を追加。これにより、自前 JS が load される瞬間には全 partial の data-* が揃っている。
+3. **CDN htmx は当面維持**: 自前 JS の bug が出ても CDN htmx が並走して機能する保険。template の `hx-*` は削除済なので CDN htmx は実質 no-op だが、HTMX core の event 監視は走る。CSP も `'unsafe-inline'` を当面維持で安全網。
+4. **`<meta name="csrf-token">` 維持**: pseudo-code の `csrf()` が依存。index.html `<head>` から削除しないこと。
+
+---
+
+## Commit 分割案
+
+PR H 内で以下の commit 順を想定:
+
+| # | Commit | 内容 |
+|---|---|---|
+| 0 | **app.js 補正** (Plan H 追加) | data-bulk-toggle-all delegation、data-bulk-scope 補助属性、triggerFrom listener 重複 attach 修正 |
+| 1 | partials/stats.html / requests.html / tool-uses.html 書換 + tests/test_dashboard_inline_assets.py 追加（該当 partial の test のみ enable、他 partial は skip） | 簡易 partial と test を 1:1 で同時 commit、CI 緑維持 |
+| 2 | partials/inbox.html 書換 + bulk action / json-body 対応 + tests 該当 partial enable | bulk action / json-body / data-bulk-toggle-all 動作 |
+| 3 | partials/whitelist.html 書換 + url-suggest rename + tests 該当 partial enable | form 数最多、url-suggest IIFE 削除、`data-target` → `data-suggest-target` rename |
+| 4 | index.html 書換 + 自前 CSS/JS link 追加 + tab nav data-tab + hx-headers 削除 + tests 該当 partial enable | 中核、自前 JS が初めて load される、aria-* 補強、`{% if asset_version %}?v={{ ... }}{% endif %}` 統一 |
+| 5 | tests/e2e/test_dashboard.py selector 追従 | E2E が新仕様で動くこと確認 |
+
+> **Commit 0 が必要な理由（Rev.2 重要）**: PR G app.js には `data-bulk-toggle-all` delegation が無く、PR H で template だけ書換えても全選択 checkbox が機能しない。app.js を template 書換より **先に** 補正することで、各 partial 書換時に全機能が揃った状態で動作確認できる。
+>
+> **中間 commit の機能性について**: 各 partial 書換 commit (1〜3) では、書換済 partial は自前 JS で動作するが、まだ書換えていない partial は CDN htmx で動作（hx-* がまだ残っている）。index.html commit (4) で自前 JS が初めて全画面に link されるが、それまでは CDN htmx のみで全機能が壊れない。**dashboard は中間 commit でもブラウザ操作可能**。
+
+実際は 1 PR / 1 squash merge なので commit 単位は柔軟（GitHub の squash で 1 commit に集約）。ただしレビュー時に commit 履歴で書換ステップを追えるように分割する。
+
+---
+
+## TDD: tests 追加（Red → Green）
+
+`tests/test_dashboard_inline_assets.py`:
+
+```python
+"""Sprint 007 PR H: dashboard template が inline JS / CSS を含まないことを保証。
+
+ADR 0004 (Dashboard 外部依存ゼロ化) の必須要件。PR I の CSP 'self' only 厳格化の
+前提条件として、全 partial / index.html から <script> / <style> / style="..." /
+onclick= / onsubmit= 等の inline event handler を完全に削除する。
+
+raw template grep ではなく Flask test client で render 後の HTML を BeautifulSoup
+で parse することで、Jinja コメント等の false positive を回避する。
+"""
+
+import os
+import sys
+import unittest
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "bundle", "dashboard"))
+
+from app import app
+
+bs4 = pytest.importorskip("bs4")
+BeautifulSoup = bs4.BeautifulSoup
+
+
+_INLINE_HANDLERS = (
+    "onclick", "onsubmit", "onchange", "onload", "onerror",
+    "onmouseover", "onmouseout", "onfocus", "onblur",
+)
+
+
+class TestDashboardInlineAssets(unittest.TestCase):
+    """全 endpoint の render 結果に inline asset が含まれないこと。"""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        # tests 用の inbox / policy / DB を最小設定
+        # (各 endpoint が render できる程度の env が必要)
+        ...  # 実装時に必要分だけ準備
+
+    def setUp(self) -> None:
+        app.config["TESTING"] = True
+        app.config["WTF_CSRF_ENABLED"] = False
+        self.client = app.test_client()
+
+    def _get_soup(self, path: str) -> "BeautifulSoup":
+        rv = self.client.get(path)
+        self.assertEqual(rv.status_code, 200, f"GET {path} → {rv.status_code}")
+        return BeautifulSoup(rv.data, "html.parser")
+
+    def _assert_no_inline_assets(self, soup: "BeautifulSoup", endpoint: str) -> None:
+        # <script> 子要素 (text 含む) は禁止、<script src="..."> は OK
+        for s in soup.find_all("script"):
+            self.assertFalse(
+                (s.string or "").strip(),
+                f"{endpoint}: inline <script> found: {s.string[:50]!r}",
+            )
+
+        # <style> element は完全禁止
+        styles = soup.find_all("style")
+        self.assertEqual(
+            len(styles), 0,
+            f"{endpoint}: <style> element found ({len(styles)})",
+        )
+
+        # 全要素の style="..." 属性禁止
+        with_style = soup.find_all(attrs={"style": True})
+        self.assertEqual(
+            len(with_style), 0,
+            f"{endpoint}: style=\"...\" attr found on {len(with_style)} elements",
+        )
+
+        # inline event handler 禁止
+        for handler in _INLINE_HANDLERS:
+            els = soup.find_all(attrs={handler: True})
+            self.assertEqual(
+                len(els), 0,
+                f"{endpoint}: {handler}=\"...\" attr found on {len(els)} elements",
+            )
+
+    def test_index_no_inline_assets(self) -> None:
+        soup = self._get_soup("/")
+        self._assert_no_inline_assets(soup, "/")
+
+    def test_index_csrf_meta_present(self) -> None:
+        soup = self._get_soup("/")
+        meta = soup.find("meta", attrs={"name": "csrf-token"})
+        self.assertIsNotNone(meta, "<meta name=\"csrf-token\"> missing in <head>")
+        self.assertTrue(meta.get("content"), "csrf-token content empty")
+
+    def test_partial_stats_no_inline_assets(self) -> None:
+        soup = self._get_soup("/partials/stats")
+        self._assert_no_inline_assets(soup, "/partials/stats")
+
+    def test_partial_requests_no_inline_assets(self) -> None:
+        soup = self._get_soup("/partials/requests")
+        self._assert_no_inline_assets(soup, "/partials/requests")
+
+    def test_partial_tool_uses_no_inline_assets(self) -> None:
+        soup = self._get_soup("/partials/tool-uses")
+        self._assert_no_inline_assets(soup, "/partials/tool-uses")
+
+    def test_partial_inbox_no_inline_assets(self) -> None:
+        soup = self._get_soup("/partials/inbox")
+        self._assert_no_inline_assets(soup, "/partials/inbox")
+
+    def test_partial_whitelist_no_inline_assets(self) -> None:
+        soup = self._get_soup("/partials/whitelist")
+        self._assert_no_inline_assets(soup, "/partials/whitelist")
+
+    def test_data_swap_target_present_on_inbox_forms(self) -> None:
+        """inbox の accept/reject form に data-swap-target が存在。"""
+        # inbox 空 (= "未承認のリクエストはありません") では form は出ないので
+        # これは inbox が空でない fixture 前提。簡易には skip も可。
+        ...
+```
+
+## E2E test selector 追従
+
+`tests/e2e/test_dashboard.py`:
+
+| 既存 selector | 新 selector |
+|---|---|
+| `form[hx-post*="accept"] button:has-text("許可")` | `form[action*="/accept"] button:has-text("許可")` |
+| `form[hx-post*="reject"] button:has-text("却下")` | `form[action*="/reject"] button:has-text("却下")` |
+| `button:has-text("選択を一括許可")` | 同左 (text-based、selector 影響無し) |
+| `#inbox-select-all` | 同左 (id ベース) |
+
+E2E test 用の data-* 属性が必要なら `[data-test-action="accept"]` 等の追加も検討（過剰なら避ける）。
+
+---
+
+## Risk register
+
+| リスク | 軽減策 |
+|---|---|
+| **両持ち**: 同 form に hx-post と data-swap-target が並走で二重 POST | partial 単位 commit で hx-* を **完全削除** してから data-* を追加。レビュー時に diff を見て両持ちの行が無いか確認 |
+| **`<meta name="csrf-token">` 削除事故** | `tests/test_dashboard_inline_assets.py::test_index_csrf_meta_present` で防衛 |
+| **partial の inline `<script>` 削除漏れ** | BS4 ベース test で全 partial を render して assert |
+| **whitelist.html の `data-target` rename 漏れ** (Rev.2 強化) | template に `data-target` が **0 件** であることを test で assert (`soup.find_all(attrs={"data-target": True})` == []) |
+| **inline style class 化漏れ** | BS4 ベース test で `attrs={"style": True}` を 0 件 assert |
+| **`<body hx-headers='{...}'>` 削除漏れ** (Rev.2 追加) | BS4 test で body element に `hx-headers` 属性が無いことを assert |
+| **bulk-toggle-all 機能不全** (Rev.2 重要) | PR G app.js への補正 commit を本 PR 最初に置く。E2E P1 の `test_inbox_bulk_accept` で動作検証 |
+| **`data-json-body` 内の attribute injection / XSS** (Rev.2 High) | `{{ {'record_id': r._id}|tojson|forceescape }}` パターンで Jinja escape を強制。属性値全体を `data-json-body="..."` で double quote 包囲（hx-vals と同戦略）|
+| **triggerFrom listener 重複 attach** (Rev.2 追加) | `_triggerListenersByTarget` Map で同 selector への listener attach を 1 回に制限 |
+| **CDN htmx が削除済 hx-* を見つけられず動作変化** | hx-* を完全削除すれば htmx は no-op。`hx-headers` も削除しているので CSRF header 渡しの干渉も無し。並存期間は htmx が完全 idle |
+| **Flask static MIME** | PR G で test 確認済 |
+| **asset_version cache busting** | `{% if asset_version %}?v={{ asset_version }}{% endif %}` defensive (Plan G review G3 反映、本 PR で **全箇所統一**) |
+| **E2E が壊れる** | 6 ケース x P1 のみ、selector 追従で再 PASS、`make e2e` で確認 |
+| **tab content 初期 hidden** | `style="display:none"` 削除と `class="hidden"` 付与を同時、tab-requests のみ active 状態（class なし）、他 3 tab は class="hidden" |
+| **a11y (aria-*)** | tab nav に `role="tablist"` / `role="tab"` / `aria-selected`、tab content に `role="tabpanel"`、polling target に `aria-live="polite"`。app.js の click delegation で `aria-selected` を更新する追加実装 |
+| **M-1 ステータス**: PR H 完了時点ではまだ resolved していない | Plan H と CHANGELOG の文言で「PR I で M-1 完了」と明記、誤認回避 |
+
+---
+
+## 受入基準（Rev.2）
+
+- [ ] 全 template から `hx-*` 属性が消える（grep で 0 件、`hx-headers` も含む）
+- [ ] 全 template から inline `<script>` ブロック / `onclick=` / `style=` / `<style>` が消える（BS4 test で確認）
+- [ ] 全 template から `data-target=` が消える（whitelist の url-suggest が `data-suggest-target` に rename 完了）
+- [ ] index.html `<head>` に `<meta name="csrf-token">` が **残る**
+- [ ] index.html に自前 CSS/JS link 追加、`{% if asset_version %}?v={{ asset_version }}{% endif %}` 形式で統一
+- [ ] CDN htmx / pico の link は **当面維持**（PR I で削除）
+- [ ] **app.js に `data-bulk-toggle-all` delegation 追加** + triggerFrom listener 重複 attach 修正
+- [ ] **app.js に aria-selected 更新ロジック追加**（tab nav の click delegation 内）
+- [ ] `tests/test_dashboard_inline_assets.py` 新規 7+ 件 PASS
+- [ ] 既存 391 unit 全 PASS
+- [ ] `tests/e2e/test_dashboard.py` selector 追従、6 ケース全 PASS（特に `test_inbox_bulk_accept` で全選択動作確認）
+- [ ] dashboard 起動、ブラウザで全 tab 動作確認（手動 + E2E）
+
+---
+
+## Rev.2 反映マッピング（Plan review High/Medium）
+
+| # | Sev | 指摘 | 反映先 |
+|---|---|---|---|
+| H1 | High | `data-json-body` の Jinja escape pattern が抜けて attribute injection / XSS リスク | deliverables 3 に `{{ {'record_id': r._id}|tojson|forceescape }}` パターン明示、Risk register に追加 |
+| H2 | High | `toggleAllInbox` 代替の `data-bulk-toggle-all` delegation が PR G app.js に **未実装** | **commit 0 で PR G app.js を補正**、deliverables 1 に追加 |
+| M1 | Medium | Commit 順序で test Red 中間 commit が CI 緑にならない | commit 1〜4 で「partial 書換 + 該当 partial の test enable」を 1:1 でセット、未書換 partial の test は skip |
+| M2 | Medium | body の `hx-headers='{...}'` 削除が deliverables に無い | deliverables 2 に明示、Risk register に追加 |
+| M3 | Medium | onclick 削除明記 | deliverables 4 で `<li>` の onclick 削除を明記、BS4 test で全 partial 検証 |
+| M4 | Medium | form submit handler 競合 (個別 form + bulk button 同 form 内混在) | bulk button は `<button type="button">` で submit event 発火しない、form submit は `[data-swap-target]` のみ起動するため競合無し（受入基準で動作確認） |
+| M5 | Medium | triggerFrom listener 重複 attach bug | commit 0 で app.js 補正 |
+| M6 | Medium | record_id の文字種前提 | inbox.py の `_RECORD_ID_RE` で `[A-Za-z0-9:T_-]+` に制限済（既存 H-2 対策）。`tojson|forceescape` で多重防御 |
+| L1 | Low | partial 単位 commit の中間機能性 | 中間 commit でも CDN htmx が動くため操作可能、明文化 |
+| L2 | Low | `data-target` rename の `#` prefix | deliverables 4 に明示 |
+| L3 | Low | tab nav 初期 hidden | deliverables 2 で `class="hidden"` 明示 |
+| L4 | Low | status filter form vs div | deliverables 2 で `<div>` 化を明示 |
+| L5 | Low | asset_version 表記統一 | deliverables 2 で `{% if ... %}` 形式に統一 |
+| L6 | Low | Flask url_for vs ?v= 直書き | 現状の `{% if asset_version %}?v={{ asset_version }}{% endif %}` で十分、url_for は将来検討 |
+| L7 | Low | href="#" スクロール問題 | `preventDefault()` で抑止、現状 OK |
+| L8 | Low | aria-live / aria-selected | deliverables 2 で role/aria-* 付与、app.js で aria-selected 更新 |
+| L9 | Low | 未実装 test (`...`) | data-swap-target 系の fixture 依存 test は本 PR で **skip**（fixture は Sprint 008 follow-up）|
+| L10 | Low | M-1 status | Plan H と CHANGELOG で「PR I で M-1 完了」明記 |
+
+---
+
+## Rev.3 self-review + Gemini 反映
+
+### Claude self-review (Phase 1)
+
+| # | Sev | 指摘 | 対応 |
+|---|---|---|---|
+| H-1 | High | `app.config["ASSET_VERSION"]` だけでは Jinja から参照不可 → cache busting 機能死 | **本 PR で fix**: `app.py` に `@app.context_processor` 追加。tests に template render 検証 +2 件 (?v=test-sha-abc が link href に出る、空時は ?v= 自体が出ない) |
+| M-1 | Medium | `aria-labelledby="tabs"` (tablist の id) は ARIA 仕様違反、tab 要素の id を指すべき。他 3 tabpanel は aria-labelledby 自体無し | **本 PR で fix**: tab nav `<a>` に `id="tabnav-{name}"` 付与、各 tabpanel `aria-labelledby="tabnav-{name}"` 完備 |
+| M-2 | Medium | `data-poll-interval=0` semantics が Plan F/H 未仕様化 | app.js コメントには明記済、Plan F は次 PR で正本化 (Sprint 008 か follow-up issue) |
+| L-4 | Low | `_triggerListenersByTarget` Map cleanup なし (removedNodes hook 未対応) | dashboard では polling element がほぼ静的、実害小、Sprint 008 follow-up |
+| L-5 | Low | partial swap 後の master checkbox 状態リセット | 意図通り (許可後リスト変化に追従)、修正不要 |
+| L-6 | Low | `data-suggest-target="#path-{{ host|replace('.', '-') }}"` の id 衝突 (Gemini M-3 と同根) | Sprint 008 follow-up |
+
+### Gemini 再レビュー (Phase 3)
+
+| # | Sev | 指摘 | 対応 |
+|---|---|---|---|
+| GM-1 | Medium | tabindex の動的制御欠如 (WAI-ARIA Authoring Practices: active のみ tabindex=0、他は -1) | **Sprint 008 a11y follow-up**: app.js の tab click delegation に tabindex 更新追加 |
+| GM-2 | Medium | id 衝突 (`c.host|replace('.', '-')` だけでは `:` `[` 等の特殊文字に対応不足) | **Sprint 008 follow-up**: slugify or hash 化 |
+| GM-3 | Medium | `data-bulk-toggle-all` の `checkbox.checked = true` は change event 発火しない → スクリーンリーダー通知不足 | **Sprint 008 a11y follow-up**: `dispatchEvent(new Event('change'))` 追加 |
+| GL-1 | Low | `data-poll-interval="0"` を `data-poll-once="true"` 等の明示的属性に | M-2 と同根、Sprint 008 で属性名再設計 |
+| GL-2 | Low | `url_for('static', filename=..., v=asset_version)` 採用検討 | 単一 app 構成では実害なし、現状維持 |
+
+### 判定
+
+- Claude self-review: 修正必要 → H-1/M-1 修正で **通過**
+- Gemini self-review: **merge OK** (Medium 3 は Sprint 008 follow-up)
+
+a11y 残課題 (GM-1, GM-3) は **Sprint 008 で `dashboard a11y polish` task** として独立扱い (`#tabindex` / `dispatchEvent` / `slugify host id` の 3 fix で完結する小規模 task)。
+
+---
+
+## 参照
+
+- ADR 0004: `docs/dev/adr/0004-dashboard-external-deps-removal.md`
+- Plan F: `docs/plans/sprint-007-pr-f.md` (pseudo-code + data-* schema)
+- Plan G: `docs/plans/sprint-007-pr-g.md` (CSS / JS 実装の line 数 + 設計 follow-up)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ dev = [
     "flask-wtf>=1.2",  # dashboard CSRF 対策 (Sprint 005 PR B / 包括レビュー H-1)
     "tomli_w>=1.0",
     "pyyaml>=6.0",  # tests/test_dependabot_config.py で .github/dependabot.yml をパース
+    "beautifulsoup4>=4.12",  # Sprint 007 PR H: tests/test_dashboard_inline_assets.py で render 後 HTML を parse
 ]
 e2e = [
     "playwright>=1.40",

--- a/tests/e2e/test_dashboard.py
+++ b/tests/e2e/test_dashboard.py
@@ -46,7 +46,7 @@ def test_inbox_accept_writes_to_runtime(
     # confirm dialog を accept
     page.once("dialog", lambda d: d.accept())
     # form[hx-post=".../accept"] 内の button に絞る（bulk button と区別）
-    page.click('form[hx-post*="accept"] button:has-text("許可")')
+    page.click('form[action*="/accept"] button:has-text("許可")')
     # HTMX swap 完了を待ち、runtime ファイル更新まで余裕
     page.wait_for_selector("text=未承認のリクエストはありません")
 
@@ -64,7 +64,7 @@ def test_inbox_reject_marks_status_only(
     page.goto(dashboard)
     page.click("text=Inbox")
     page.wait_for_selector("text=reject.example.com")
-    page.click('form[hx-post*="reject"] button:has-text("却下")')
+    page.click('form[action*="/reject"] button:has-text("却下")')
     page.wait_for_selector("text=未承認のリクエストはありません")
 
     rt_path = workspace / ".zoo" / "policy.runtime.toml"
@@ -95,7 +95,7 @@ def test_inbox_path_accept_writes_to_paths_allow(
     page.wait_for_selector("text=api.example.com")
     page.once("dialog", lambda d: d.accept())
     # form[hx-post=".../accept"] 内の button に絞る（bulk button と区別）
-    page.click('form[hx-post*="accept"] button:has-text("許可")')
+    page.click('form[action*="/accept"] button:has-text("許可")')
     page.wait_for_selector("text=未承認のリクエストはありません")
 
     rt = tomllib.loads((workspace / ".zoo" / "policy.runtime.toml").read_text())

--- a/tests/test_dashboard_asset_version.py
+++ b/tests/test_dashboard_asset_version.py
@@ -34,6 +34,49 @@ class TestAssetVersion(unittest.TestCase):
             else:
                 app.config.pop("ASSET_VERSION", None)
 
+    def test_asset_version_injected_into_template_query(self) -> None:
+        """self-review H-1: app.config + context_processor で template の ?v=... が出る。
+
+        cache busting 機能が **実際に動く** ことを保証 (template render を検証)。
+        """
+        had_key = "ASSET_VERSION" in app.config
+        old = app.config.get("ASSET_VERSION")
+        try:
+            app.config["ASSET_VERSION"] = "test-sha-abc"
+            app.config["TESTING"] = True
+            app.config["WTF_CSRF_ENABLED"] = False
+            client = app.test_client()
+            rv = client.get("/")
+            self.assertEqual(rv.status_code, 200)
+            # link / script tag に ?v=test-sha-abc が含まれる
+            self.assertIn(b"app.css?v=test-sha-abc", rv.data)
+            self.assertIn(b"app.js?v=test-sha-abc", rv.data)
+        finally:
+            if had_key:
+                app.config["ASSET_VERSION"] = old
+            else:
+                app.config.pop("ASSET_VERSION", None)
+
+    def test_asset_version_empty_omits_query(self) -> None:
+        """default (空文字) では `?v=` query 自体が出力されない (defensive Jinja)。"""
+        had_key = "ASSET_VERSION" in app.config
+        old = app.config.get("ASSET_VERSION")
+        try:
+            app.config["ASSET_VERSION"] = ""
+            app.config["TESTING"] = True
+            app.config["WTF_CSRF_ENABLED"] = False
+            client = app.test_client()
+            rv = client.get("/")
+            self.assertEqual(rv.status_code, 200)
+            # link href は ?v= 無しで終わる (e.g., "/static/app.css">)
+            self.assertNotIn(b"app.css?v=", rv.data)
+            self.assertNotIn(b"app.js?v=", rv.data)
+        finally:
+            if had_key:
+                app.config["ASSET_VERSION"] = old
+            else:
+                app.config.pop("ASSET_VERSION", None)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_dashboard_inline_assets.py
+++ b/tests/test_dashboard_inline_assets.py
@@ -1,0 +1,207 @@
+"""Sprint 007 PR H: dashboard template が inline JS / CSS を含まないことを保証。
+
+ADR 0004 (Dashboard 外部依存ゼロ化) の必須要件。PR I の CSP 'self' only
+厳格化の前提条件として、全 partial / index.html から:
+  - <script>...</script> (inline body 持ち、外部 src のみ許可)
+  - <style>...</style> (CDN 経由でも自前でも、element 自体禁止)
+  - style="..." 属性 (CSP style-src-attr 'unsafe-inline' を要求)
+  - onclick= / onsubmit= 等の inline event handler
+を完全に削除する。
+
+raw template grep ではなく Flask test client で render 後の HTML を
+BeautifulSoup で parse することで、Jinja コメント等の false positive
+を回避する (Plan F Gemini レビュー G4)。
+"""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+import sys
+import tempfile
+import unittest
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "bundle", "dashboard"))
+
+from app import app
+
+bs4 = pytest.importorskip("bs4")
+BeautifulSoup = bs4.BeautifulSoup
+
+
+_INLINE_HANDLERS = (
+    "onclick",
+    "onsubmit",
+    "onchange",
+    "onload",
+    "onerror",
+    "onmouseover",
+    "onmouseout",
+    "onfocus",
+    "onblur",
+    "oninput",
+    "onkeydown",
+    "onkeyup",
+    "onkeypress",
+)
+
+
+class _BaseInlineAssetsTest(unittest.TestCase):
+    """共通: TESTING + minimal DB + inbox dir を fixture 化。"""
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        # minimal DB (read-only mount される harness.db を擬似)
+        db_path = os.path.join(self._tmp.name, "harness.db")
+        db = sqlite3.connect(db_path)
+        db.executescript(
+            """
+            CREATE TABLE requests (id INTEGER PRIMARY KEY, ts TEXT, host TEXT,
+                method TEXT, url TEXT, status TEXT, body_size INTEGER);
+            CREATE TABLE blocks (id INTEGER PRIMARY KEY, ts TEXT, host TEXT, reason TEXT);
+            CREATE TABLE tool_uses (id INTEGER PRIMARY KEY, ts TEXT,
+                tool_name TEXT, input TEXT, input_size INTEGER);
+            CREATE TABLE alerts (id INTEGER PRIMARY KEY, ts TEXT, type TEXT, detail TEXT);
+            """
+        )
+        db.commit()
+        db.close()
+        os.environ["DB_PATH"] = db_path
+
+        # minimal policy.toml
+        policy_path = os.path.join(self._tmp.name, "policy.toml")
+        with open(policy_path, "w") as f:
+            f.write("[domains.allow]\nlist = []\n[paths.allow]\n")
+        os.environ["POLICY_PATH"] = policy_path
+
+        # inbox dir
+        inbox_dir = os.path.join(self._tmp.name, "inbox")
+        os.makedirs(inbox_dir)
+        os.environ["INBOX_DIR"] = inbox_dir
+
+        app.config["TESTING"] = True
+        app.config["WTF_CSRF_ENABLED"] = False
+        self.client = app.test_client()
+
+    def tearDown(self) -> None:
+        self._tmp.cleanup()
+
+    def _get_soup(self, path: str) -> "BeautifulSoup":
+        rv = self.client.get(path)
+        self.assertEqual(rv.status_code, 200, f"GET {path} → {rv.status_code}")
+        return BeautifulSoup(rv.data, "html.parser")
+
+    def _assert_no_inline_assets(self, soup: "BeautifulSoup", endpoint: str) -> None:
+        # <script> 子要素 (text 含む) は禁止、<script src="..."> は OK
+        inline_scripts = []
+        for s in soup.find_all("script"):
+            text = (s.string or "").strip()
+            if text:
+                inline_scripts.append(text[:80])
+        self.assertEqual(
+            inline_scripts, [],
+            f"{endpoint}: inline <script> found ({len(inline_scripts)}): "
+            f"{inline_scripts!r}",
+        )
+
+        # <style> element は完全禁止
+        styles = soup.find_all("style")
+        self.assertEqual(
+            len(styles), 0,
+            f"{endpoint}: <style> element found ({len(styles)})",
+        )
+
+        # 全要素の style="..." 属性禁止
+        with_style = soup.find_all(attrs={"style": True})
+        self.assertEqual(
+            len(with_style), 0,
+            f"{endpoint}: style=\"...\" attr found on {len(with_style)} elements: "
+            f"{[el.name for el in with_style[:5]]}",
+        )
+
+        # inline event handler 禁止
+        for handler in _INLINE_HANDLERS:
+            els = soup.find_all(attrs={handler: True})
+            self.assertEqual(
+                len(els), 0,
+                f"{endpoint}: {handler}=\"...\" attr found on {len(els)} elements",
+            )
+
+        # data-target= が残っていないこと (whitelist の url-suggest が data-suggest-target に rename)
+        with_data_target = soup.find_all(attrs={"data-target": True})
+        self.assertEqual(
+            len(with_data_target), 0,
+            f"{endpoint}: data-target= found on {len(with_data_target)} elements "
+            f"(should be data-suggest-target after Sprint 007 PR H rename)",
+        )
+
+        # hx-* 属性が残っていないこと (Sprint 007 PR H で完全削除)
+        all_attrs_hx = []
+        for el in soup.find_all(True):
+            for attr in el.attrs:
+                if attr.startswith("hx-"):
+                    all_attrs_hx.append((el.name, attr))
+        self.assertEqual(
+            all_attrs_hx, [],
+            f"{endpoint}: hx-* attributes found: {all_attrs_hx[:5]!r} (should be 0)",
+        )
+
+
+class TestIndexInlineAssets(_BaseInlineAssetsTest):
+    def test_no_inline_assets(self) -> None:
+        soup = self._get_soup("/")
+        self._assert_no_inline_assets(soup, "/")
+
+    def test_csrf_meta_present(self) -> None:
+        soup = self._get_soup("/")
+        meta = soup.find("meta", attrs={"name": "csrf-token"})
+        self.assertIsNotNone(meta, "<meta name=\"csrf-token\"> missing in <head>")
+        self.assertTrue(meta.get("content"), "csrf-token content empty")
+
+    def test_self_hosted_static_links_present(self) -> None:
+        soup = self._get_soup("/")
+        # /static/app.css への link 存在
+        links = [l for l in soup.find_all("link", rel="stylesheet")
+                 if "/static/app.css" in (l.get("href") or "")]
+        self.assertGreater(len(links), 0, "/static/app.css link missing")
+        # /static/app.js への script 存在
+        scripts = [s for s in soup.find_all("script")
+                   if "/static/app.js" in (s.get("src") or "")]
+        self.assertGreater(len(scripts), 0, "/static/app.js script missing")
+
+
+class TestPartialStatsInlineAssets(_BaseInlineAssetsTest):
+    def test_no_inline_assets(self) -> None:
+        soup = self._get_soup("/partials/stats")
+        self._assert_no_inline_assets(soup, "/partials/stats")
+
+
+class TestPartialRequestsInlineAssets(_BaseInlineAssetsTest):
+    def test_no_inline_assets(self) -> None:
+        soup = self._get_soup("/partials/requests")
+        self._assert_no_inline_assets(soup, "/partials/requests")
+
+
+class TestPartialToolUsesInlineAssets(_BaseInlineAssetsTest):
+    def test_no_inline_assets(self) -> None:
+        soup = self._get_soup("/partials/tool-uses")
+        self._assert_no_inline_assets(soup, "/partials/tool-uses")
+
+
+class TestPartialInboxInlineAssets(_BaseInlineAssetsTest):
+    def test_no_inline_assets(self) -> None:
+        # inbox は空でも items=[] でテンプレ render が通る (else branch)
+        soup = self._get_soup("/partials/inbox")
+        self._assert_no_inline_assets(soup, "/partials/inbox")
+
+
+class TestPartialWhitelistInlineAssets(_BaseInlineAssetsTest):
+    def test_no_inline_assets(self) -> None:
+        soup = self._get_soup("/partials/whitelist")
+        self._assert_no_inline_assets(soup, "/partials/whitelist")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_dashboard_static.py
+++ b/tests/test_dashboard_static.py
@@ -50,6 +50,10 @@ class TestStaticAssets(unittest.TestCase):
             b"removedNodes",
             b"_pollTimers",
             b"document.hidden",
+            # Plan H 追加: bulk toggle-all delegation + triggerFrom 重複 attach 修正
+            b"data-bulk-toggle-all",
+            b"_triggerListenersByTarget",
+            b"aria-selected",
         ):
             self.assertIn(ident, rv.data, f"missing required identifier: {ident!r}")
 

--- a/uv.lock
+++ b/uv.lock
@@ -15,6 +15,7 @@ dependencies = [
 
 [package.optional-dependencies]
 dev = [
+    { name = "beautifulsoup4" },
     { name = "flask" },
     { name = "flask-wtf" },
     { name = "pytest" },
@@ -28,6 +29,7 @@ e2e = [
 
 [package.metadata]
 requires-dist = [
+    { name = "beautifulsoup4", marker = "extra == 'dev'", specifier = ">=4.12" },
     { name = "flask", marker = "extra == 'dev'", specifier = ">=3.1" },
     { name = "flask-wtf", marker = "extra == 'dev'", specifier = ">=1.2" },
     { name = "playwright", marker = "extra == 'e2e'", specifier = ">=1.40" },
@@ -46,6 +48,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4", size = 7288, upload-time = "2025-11-10T22:07:42.062Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320", size = 5303, upload-time = "2025-11-10T22:07:40.673Z" },
+]
+
+[[package]]
+name = "beautifulsoup4"
+version = "4.14.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "soupsieve" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b0/1c6a16426d389813b48d95e26898aff79abbde42ad353958ad95cc8c9b21/beautifulsoup4-4.14.3.tar.gz", hash = "sha256:6292b1c5186d356bba669ef9f7f051757099565ad9ada5dd630bd9de5fa7fb86", size = 627737, upload-time = "2025-11-30T15:08:26.084Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1a/39/47f9197bdd44df24d67ac8893641e16f386c984a0619ef2ee4c51fbbc019/beautifulsoup4-4.14.3-py3-none-any.whl", hash = "sha256:0918bfe44902e6ad8d57732ba310582e98da931428d231a5ecb9e7c703a735bb", size = 107721, upload-time = "2025-11-30T15:08:24.087Z" },
 ]
 
 [[package]]
@@ -581,6 +596,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
+]
+
+[[package]]
+name = "soupsieve"
+version = "2.8.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/ae/2d9c981590ed9999a0d91755b47fc74f74de286b0f5cee14c9269041e6c4/soupsieve-2.8.3.tar.gz", hash = "sha256:3267f1eeea4251fb42728b6dfb746edc9acaffc4a45b27e19450b676586e8349", size = 118627, upload-time = "2026-01-20T04:27:02.457Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/46/2c/1462b1d0a634697ae9e55b3cecdcb64788e8b7d63f54d923fcd0bb140aed/soupsieve-2.8.3-py3-none-any.whl", hash = "sha256:ed64f2ba4eebeab06cc4962affce381647455978ffc1e36bb79a545b91f45a95", size = 37016, upload-time = "2026-01-20T04:27:01.012Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

ADR 0004 のメイン作業。dashboard の全 template (index.html + 5 partial) を **自前 vanilla JS の declarative API (data-*)** に置換し、inline `<script>` / `<style>` / `style=` / `onclick=` を **完全削除**。CDN htmx/pico は当面維持 (PR I で削除)。`<meta name=\"csrf-token\">` は維持 (csrf() helper 依存)。

## 主要な変更

### 1. app.js 補正 (PR G 漏れ + Plan H で発覚した bug)
- **`data-bulk-toggle-all` delegation 追加** (全選択 checkbox の代替、PR G の見逃し)
- **`_triggerListenersByTarget` Map で triggerFrom 重複 attach 防止** (setupPolls 再呼出時の listener N→2N→4N 問題)
- tab nav click で **`aria-selected` 更新** 追加
- **`data-poll-interval=\"0\"` を「load only」semantics 化** (HTMX hx-trigger=load 互換)

### 2. app.py 修正 (self-review H-1)
- `@app.context_processor` 追加で `{{ asset_version }}` を Jinja で参照可能に。**cache busting 機能死を修正**。

### 3. template 全書換
| File | 変更 |
|---|---|
| index.html | hx-* / inline script・style・onclick 全削除、自前 CSS/JS link 追加、tab nav data-tab + aria-* 完備 |
| inbox.html | data-json-body は `\\|tojson\\|forceescape` で XSS 完全防御、bulk button + table を `<div data-bulk-scope=\"inbox\">` で包む |
| whitelist.html | 6 form を data-swap-target に、url-suggest を `data-suggest-target=\"#path-...\"` に rename (data-target 既存使用と命名衝突回避) |
| requests/tool-uses.html | inline style → class=\"path-cell\" |

### 4. テスト
- **`tests/test_dashboard_inline_assets.py`** 新規 8 件 (BS4 ベース、全 6 endpoint で hx-* / data-target= / inline asset 不在を assert)
- **`tests/test_dashboard_asset_version.py`** +2 件 (template render で ?v=... が実際に出ることを検証)
- `tests/e2e/test_dashboard.py` selector 追従

### 5. 依存追加
- pyproject.toml に \`beautifulsoup4>=4.12\` ([dev])

## レビュー履歴

| Rev | フェーズ | 反映指摘 |
|---|---|---|
| Plan Rev.1→Rev.2 | Plan review (Claude + Gemini 並行) | High 2 (data-json-body escape / bulk-toggle-all 漏れ) + Medium 6 |
| Plan Rev.3 / 実装 | self-review (Claude) | High 1 (cache busting 機能死) + Medium 1 (aria-labelledby) を **本 PR で fix** |
| Plan Rev.3 | Gemini 再レビュー | merge OK (a11y Medium 3 は Sprint 008 follow-up: tabindex / id slugify / dispatchEvent) |

## テスト結果

- 新規 8 件 + asset_version 拡張 +2 件 PASS
- 既存 391 → **396 件 PASS** (regression なし)
- E2E P1 **7/7 PASS** (sandbox 解除環境)

## 注意点

- 包括レビュー **M-1 (CDN 経由の SRI 無し pico/htmx) は PR I で完了予定**。本 PR では CDN link 維持 + CSP 'unsafe-inline' 維持の中間状態
- a11y polish (tabindex 動的更新 / `dispatchEvent('change')` / id slugify) は Sprint 008 で independent task として対応

## 次の PR

- **PR I**: CDN link 削除、CSP \`'self'\` 厳格化、E2E オフライン動作確認、M-1 / L-6 resolved マーク

## Test plan

- [x] \`uv run pytest tests/ --ignore=tests/e2e\` 全 PASS (396 件)
- [x] \`make e2e\` (P1 7 件) 全 PASS
- [x] BS4 inline asset test で全 endpoint clean
- [x] cache busting 機能テスト (?v=... が出力される)
- [ ] (CI で) Unit x3 + Audit + Compose verify + E2E P1
- [ ] dashboard 起動して手動操作確認 (Sprint 完了時に user smoke で実施予定)

🤖 Generated with [Claude Code](https://claude.com/claude-code)