### PR TITLE
:bug: fix E2E P2: proxy non-root user の bundle/certs/ 書込権限

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,11 +162,19 @@ jobs:
       - name: Install dependencies
         run: uv sync --extra dev --extra e2e
 
-      - name: Prepare bind-mount targets (runtime policy + locks dir)
+      - name: Prepare bind-mount targets (runtime policy + locks + certs dir)
         run: |
           touch bundle/policy.runtime.toml
           # Sprint 006 PR F: locks dir 不在だと Docker が file 化するので事前作成
           mkdir -p bundle/locks
+          # Sprint 005 PR C (H-3) hardening: proxy container は user: "1000:1000"
+          # 固定 (mitmproxy image default)。CI runner の bundle/certs/ owner と
+          # 異なるため、mitmproxy が CA cert (/certs/mitmproxy-ca.pem) を書け
+          # ない (Permission denied)。chmod 0777 で proxy non-root user が書込
+          # 可能化する (CA private key の機密性は container 内の mitmproxy
+          # process に閉じる、ホスト dir 自体は test 専用 ephemeral)。
+          mkdir -p bundle/certs
+          chmod 0777 bundle/certs
 
       - name: Build base image
         run: docker build -t agent-zoo-base:latest -f bundle/container/Dockerfile.base bundle/

--- a/tests/e2e/test_proxy_block.py
+++ b/tests/e2e/test_proxy_block.py
@@ -54,6 +54,12 @@ def proxy_up():
     # Sprint 006 PR F: locks dir を bind mount 用に確保 (mount source 不在で
     # Docker が file を作る誤検知を防ぐ)
     (BUNDLE / "locks").mkdir(exist_ok=True)
+    # Sprint 005 PR C (H-3) hardening: proxy container は user: "1000:1000"
+    # 固定。bundle/certs/ owner と異なる場合 mitmproxy が CA cert を書けない
+    # (Permission denied)。0777 で UID 不一致でも書込可能化 (test ephemeral dir)
+    certs_dir = BUNDLE / "certs"
+    certs_dir.mkdir(exist_ok=True)
+    os.chmod(certs_dir, 0o777)
     try:
         subprocess.run(
             ["docker", "compose", "up", "-d", "proxy"],


### PR DESCRIPTION
## Summary

Sprint 005 PR C (H-3 container hardening) 以降、main post-merge で E2E P2 が **4 連続失敗** していた問題を修正。

## 原因

`bundle/docker-compose.yml` で proxy は `user: "1000:1000"` 固定 (mitmproxy image default user との整合)。CI runner / local の `bundle/certs/` owner が異なる場合、mitmproxy が CA cert (`/certs/mitmproxy-ca.pem`) を書けず `PermissionError: [Errno 13]` で startup 失敗。

PR 段階で E2E P2 は SKIPPED (post-merge job) のため気付かれず、Sprint 007 PR G〜I + chore/cleanup の main merge 後で連続失敗:
- #24622305975 (PR G merge 後)
- #24623792215 (PR H merge 後)
- #24624112803 (PR I merge 後)
- #24624534305 (chore/cleanup merge 後)

## 修正

| ファイル | 内容 |
|---|---|
| `.github/workflows/ci.yml` | e2e-proxy job の Prepare bind-mount step で `mkdir -p bundle/certs && chmod 0777 bundle/certs` 追加 |
| `tests/e2e/test_proxy_block.py::proxy_up` | 同等の準備を fixture に追加 (local `make e2e-all` 用) |

bundle/certs/ は test ephemeral dir で本番運用 (zoo init で workspace 配下の .zoo/certs/) には影響なし。CA private key の機密性は container 内の mitmproxy process scope に閉じる。

## 検証

- ローカル `uv run pytest tests/e2e/test_proxy_block.py -v` で **3/3 PASS** (Docker daemon 起動済 macOS 環境)
- CI で post-merge E2E P2 が green に戻ること (本 PR merge 後の main で確認)

## Test plan

- [x] ローカル E2E P2 全 PASS
- [ ] CI 全 PASS (Unit x3 + Audit + Compose verify + E2E P1)
- [ ] main merge 後の post-merge E2E P2 が green

🤖 Generated with [Claude Code](https://claude.com/claude-code)