### PR TITLE
:bug: fix E2E P2 (follow-up): bundle/{data,locks} も chmod 0777

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,19 +162,18 @@ jobs:
       - name: Install dependencies
         run: uv sync --extra dev --extra e2e
 
-      - name: Prepare bind-mount targets (runtime policy + locks + certs dir)
+      - name: Prepare bind-mount targets (runtime policy + locks + certs + data dir)
         run: |
           touch bundle/policy.runtime.toml
-          # Sprint 006 PR F: locks dir 不在だと Docker が file 化するので事前作成
-          mkdir -p bundle/locks
           # Sprint 005 PR C (H-3) hardening: proxy container は user: "1000:1000"
-          # 固定 (mitmproxy image default)。CI runner の bundle/certs/ owner と
-          # 異なるため、mitmproxy が CA cert (/certs/mitmproxy-ca.pem) を書け
-          # ない (Permission denied)。chmod 0777 で proxy non-root user が書込
-          # 可能化する (CA private key の機密性は container 内の mitmproxy
-          # process に閉じる、ホスト dir 自体は test 専用 ephemeral)。
-          mkdir -p bundle/certs
-          chmod 0777 bundle/certs
+          # 固定 (mitmproxy image default)。CI runner Linux では bind mount された
+          # ホスト dir の owner が runner user (1001) のままなので、proxy 1000 が
+          # 書けない (Permission denied)。chmod 0777 で UID 不一致でも書込可能化
+          # (test 専用 ephemeral dir、本番運用 (zoo init で .zoo/) には影響なし)。
+          # macOS Docker Desktop は VirtioFS の UID マッピングが寛容なので
+          # ローカルでは問題が顕在化しない。
+          mkdir -p bundle/certs bundle/locks bundle/data
+          chmod 0777 bundle/certs bundle/locks bundle/data
 
       - name: Build base image
         run: docker build -t agent-zoo-base:latest -f bundle/container/Dockerfile.base bundle/

--- a/tests/e2e/test_proxy_block.py
+++ b/tests/e2e/test_proxy_block.py
@@ -51,15 +51,15 @@ def proxy_up():
     env = {**os.environ, "HOST_UID": str(os.getuid())}
     # CI / 初回起動で bind-mount 対象ファイルが無いと Docker が dir 化してしまうため事前 touch
     (BUNDLE / "policy.runtime.toml").touch(exist_ok=True)
-    # Sprint 006 PR F: locks dir を bind mount 用に確保 (mount source 不在で
-    # Docker が file を作る誤検知を防ぐ)
-    (BUNDLE / "locks").mkdir(exist_ok=True)
     # Sprint 005 PR C (H-3) hardening: proxy container は user: "1000:1000"
-    # 固定。bundle/certs/ owner と異なる場合 mitmproxy が CA cert を書けない
-    # (Permission denied)。0777 で UID 不一致でも書込可能化 (test ephemeral dir)
-    certs_dir = BUNDLE / "certs"
-    certs_dir.mkdir(exist_ok=True)
-    os.chmod(certs_dir, 0o777)
+    # 固定。bind mount された host dir の owner が違う場合 (Linux CI で顕著)、
+    # proxy 非 root user が書けない (Permission denied)。
+    # 対象: certs (CA cert 作成) / locks (policy_lock fcntl) / data (sqlite DB 作成)
+    # 0777 で UID 不一致でも書込可能化 (test ephemeral dir、本番には影響なし)
+    for sub in ("certs", "locks", "data"):
+        d = BUNDLE / sub
+        d.mkdir(exist_ok=True)
+        os.chmod(d, 0o777)
     try:
         subprocess.run(
             ["docker", "compose", "up", "-d", "proxy"],


### PR DESCRIPTION
## Summary

PR #54 の follow-up。`bundle/certs` だけ chmod 0777 では足りず、main post-merge run #24624844848 で残 2 dir で permission denied:

- `/data`: sqlite DB (harness.db) 作成で `OperationalError: unable to open database file`
- `/locks`: policy_lock fcntl primary lock dir 書込失敗 (warn passthrough、致命ではないが log noise)

## 原因 (3 dir 共通)

- proxy container は `user: "1000:1000"` 固定 (mitmproxy image default、Sprint 005 PR C H-3 hardening)
- CI runner Linux の bind mount owner = runner user 1001
- → proxy 1000 が 1001 owner dir に書けない
- ローカル macOS Docker Desktop は **VirtioFS の UID マッピングが寛容** なので顕在化しなかった (PR #54 がローカル PASS なのに CI fail した理由)

## 修正

| ファイル | 内容 |
|---|---|
| `.github/workflows/ci.yml` | `bundle/{certs,locks,data}` を mkdir + chmod 0777 で一括対応 |
| `tests/e2e/test_proxy_block.py::proxy_up` | 同等の準備を fixture に統合 (3 dir loop) |

## 検証

- ローカル `uv run pytest tests/e2e/test_proxy_block.py -v` で **3/3 PASS** (regression なし)
- post-merge CI で本来 SKIP の E2E P2 が green になることを main merge 後に確認

## Test plan

- [x] ローカル 3/3 PASS
- [ ] CI 全 PASS
- [ ] main merge 後の post-merge E2E P2 が **green** に戻る (本 PR の真の検証)

🤖 Generated with [Claude Code](https://claude.com/claude-code)