### PR TITLE
:bug: zoo init: .zoo/certs/extra/ + .gitkeep を作成 (zoo build 失敗修正)

### DIFF
--- a/src/zoo/api.py
+++ b/src/zoo/api.py
@@ -125,8 +125,14 @@ def init(target_dir: str | Path = ".", *, force: bool = False) -> Path:
     # Runtime dirs/files（.zoo/ 配下）
     # Sprint 006 PR F: locks/ は cross-container policy lock 用 (M-8)。proxy /
     # dashboard 両方から bind mount される。
-    for d in ("data", "certs", "inbox", "locks"):
-        (zoo_target / d).mkdir(exist_ok=True)
+    # certs/extra: Dockerfile.base が `COPY certs/extra/ ...` で取り込むため
+    # 空でも dir 自体が必須 (D-1 ユーザー追加 CA、`.gitkeep` 配置で空 dir 維持)
+    for d in ("data", "certs", "certs/extra", "inbox", "locks"):
+        (zoo_target / d).mkdir(parents=True, exist_ok=True)
+    # certs/extra/.gitkeep: docker build が空 dir を skip しないよう placeholder
+    extra_gitkeep = zoo_target / "certs" / "extra" / ".gitkeep"
+    if not extra_gitkeep.exists():
+        extra_gitkeep.touch()
     (zoo_target / "policy.runtime.toml").touch(exist_ok=True)
 
     return target

--- a/tests/test_zoo_init.py
+++ b/tests/test_zoo_init.py
@@ -58,6 +58,9 @@ class TestInit:
         # runtime dirs
         assert (target / ".zoo" / "data").is_dir()
         assert (target / ".zoo" / "certs").is_dir()
+        # zoo build (Dockerfile.base COPY certs/extra/ ...) で必要 + .gitkeep で空 dir 維持
+        assert (target / ".zoo" / "certs" / "extra").is_dir()
+        assert (target / ".zoo" / "certs" / "extra" / ".gitkeep").is_file()
         assert (target / ".zoo" / "inbox").is_dir()
         # Sprint 006 PR F: cross-container policy lock 用 dir
         assert (target / ".zoo" / "locks").is_dir()


### PR DESCRIPTION
## Summary

ユーザー報告 (dogfood-dashboard.sh で再現):

```
ERROR [2/9] COPY certs/extra/ /usr/local/share/ca-certificates/extra/
failed to compute cache key: '/certs/extra': not found
```

## 原因

`Dockerfile.base` は build 時に `COPY certs/extra/ ...` で D-1 (ユーザー追加 CA) を取り込むため、build context 内に **空でも `certs/extra/` dir が必須**。
source repo の `bundle/certs/extra/.gitkeep` は track 済 (gitignore allow パターン) だが、配布用の `zoo init` の runtime dir 作成ループ (`data/certs/inbox/locks`) に **`extra` サブディレクトリが含まれていなかった**。

結果: `zoo init` 後の workspace は `.zoo/certs/` (空) しか作らず、`zoo build` が COPY で fail。

## 修正

| ファイル | 内容 |
|---|---|
| `src/zoo/api.py::init` | runtime dir loop に `"certs/extra"` 追加、`parents=True` 化、`.gitkeep` を touch (docker build が空 dir を skip しない placeholder) |
| `tests/test_zoo_init.py::test_copies_files_and_creates_zoo_dir` | `.zoo/certs/extra` dir + `.gitkeep` 存在を assert |

## 検証

- `uv run pytest tests/test_zoo_init.py` で **10/10 PASS**
- 全 unit **413 PASS** (regression なし)

## ユーザー側の即時 workaround (PR merge 前)

```bash
cd /tmp/zoo-trial
mkdir -p .zoo/certs/extra
touch .zoo/certs/extra/.gitkeep
zoo build --agent claude
```

## Test plan

- [x] tests/test_zoo_init.py PASS
- [x] 既存 unit regression なし
- [ ] CI 全 PASS
- [ ] (user) 修正後に `./scripts/dogfood-dashboard.sh` で zoo build が通る

🤖 Generated with [Claude Code](https://claude.com/claude-code)