### PR TITLE
:bug: fix(e2e): P2 proxy を bundle/policy.toml (profile copy) で起動

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,13 @@
 # Runtime policy (dashboard writes here, base policy.toml is preserved)
 *.runtime.toml
 
+# issue #66 で bundle/policy.toml は bundle/policy/*.toml 5 profile に分離された。
+# E2E P2 fixture (tests/e2e/test_proxy_block.py::proxy_up) が一時的に
+# bundle/policy/all.toml を bundle/policy.toml として copy する (source bundle
+# で直接 docker compose する時の互換層)。teardown で削除されるが、途中で Ctrl-C
+# された場合のゴミ commit を safety net で防ぐ。
+bundle/policy.toml
+
 # Runtime artifacts under bundle/ (ADR 0002): DB / certs は git 管理外
 bundle/data/*.db
 bundle/data/*.db-wal

--- a/tests/e2e/test_proxy_block.py
+++ b/tests/e2e/test_proxy_block.py
@@ -51,6 +51,20 @@ def proxy_up():
     env = {**os.environ, "HOST_UID": str(os.getuid())}
     # CI / 初回起動で bind-mount 対象ファイルが無いと Docker が dir 化してしまうため事前 touch
     (BUNDLE / "policy.runtime.toml").touch(exist_ok=True)
+    # issue #66 で bundle/policy.toml (単一 file) は bundle/policy/*.toml (5 profile)
+    # に分離された。本番 flow では `zoo init --policy <profile>` が <workspace>/
+    # .zoo/policy.toml を生成するが、E2E P2 は source bundle で直接 docker
+    # compose up するため bundle/policy.toml が不在。Docker は bind-mount 対象
+    # が無いと自動で dir を作成 → proxy container で IsADirectoryError になる。
+    # bundle/policy/all.toml (旧 default 相当) を bundle/policy.toml として
+    # 一時 copy して回避し、teardown で削除する。
+    policy_dst = BUNDLE / "policy.toml"
+    policy_dst_created = False
+    if not policy_dst.exists():
+        policy_src = BUNDLE / "policy" / "all.toml"
+        if policy_src.exists():
+            shutil.copy(policy_src, policy_dst)
+            policy_dst_created = True
     # Sprint 005 PR C (H-3) hardening: proxy container は user: "1000:1000"
     # 固定。bind mount された host dir の owner が違う場合 (Linux CI で顕著)、
     # proxy 非 root user が書けない (Permission denied)。
@@ -99,6 +113,8 @@ def proxy_up():
         )
         # 事前 touch した空ファイルをローカル環境から除去（.gitignore 済だが dev の作業 dir を汚さない）
         (BUNDLE / "policy.runtime.toml").unlink(missing_ok=True)
+        if policy_dst_created:
+            policy_dst.unlink(missing_ok=True)
 
 
 def _curl_via_proxy(url: str) -> int:

--- a/tests/test_release_prepare_script.py
+++ b/tests/test_release_prepare_script.py
@@ -28,6 +28,25 @@ SCRIPT = pathlib.Path("scripts/release-prepare.sh").resolve()
 WORKFLOW = pathlib.Path(".github/workflows/release.yml")
 
 
+def _isolated_git_env() -> dict[str, str]:
+    """test subprocess 用 env。
+
+    GIT_CONFIG_GLOBAL / GIT_CONFIG_SYSTEM を /dev/null に向け、maintainer の
+    ~/.gitconfig (commit.gpgsign / tag.gpgsign 等) による test 挙動変化を
+    遮断する (test isolation)。例: tag.gpgsign=true が有効だと lightweight
+    tag 作成すら "no tag message" で fail する。
+    """
+    return {
+        **os.environ,
+        "GIT_AUTHOR_NAME": "test",
+        "GIT_AUTHOR_EMAIL": "test@test",
+        "GIT_COMMITTER_NAME": "test",
+        "GIT_COMMITTER_EMAIL": "test@test",
+        "GIT_CONFIG_GLOBAL": "/dev/null",
+        "GIT_CONFIG_SYSTEM": "/dev/null",
+    }
+
+
 def _init_mini_repo(root: pathlib.Path, version: str = "0.1.0") -> None:
     """tmp_path に git repo + minimal pyproject.toml を用意する。"""
     (root / "pyproject.toml").write_text(
@@ -45,13 +64,7 @@ def _init_mini_repo(root: pathlib.Path, version: str = "0.1.0") -> None:
         ).strip()
         + "\n"
     )
-    env = {
-        **os.environ,
-        "GIT_AUTHOR_NAME": "test",
-        "GIT_AUTHOR_EMAIL": "test@test",
-        "GIT_COMMITTER_NAME": "test",
-        "GIT_COMMITTER_EMAIL": "test@test",
-    }
+    env = _isolated_git_env()
     for cmd in [
         ["git", "init", "-q", "-b", "main"],
         ["git", "add", "pyproject.toml"],
@@ -65,17 +78,10 @@ def _run_script(
     *args: str,
     stdin: str | None = None,
 ) -> subprocess.CompletedProcess:
-    env = {
-        **os.environ,
-        "GIT_AUTHOR_NAME": "test",
-        "GIT_AUTHOR_EMAIL": "test@test",
-        "GIT_COMMITTER_NAME": "test",
-        "GIT_COMMITTER_EMAIL": "test@test",
-    }
     return subprocess.run(
         [str(SCRIPT), *args],
         cwd=root,
-        env=env,
+        env=_isolated_git_env(),
         capture_output=True,
         text=True,
         input=stdin,
@@ -330,7 +336,14 @@ def test_rejects_shell_injection_via_version_arg(tmp_path):
 
 def test_rejects_existing_tag(tmp_path):
     _init_mini_repo(tmp_path, version="0.1.0")
-    subprocess.run(["git", "tag", "v0.1.0"], cwd=tmp_path, check=True)
+    # isolated env で tag 作成 (maintainer の global tag.gpgsign=true が
+    # "no tag message" を強制するのを回避)
+    subprocess.run(
+        ["git", "tag", "v0.1.0"],
+        cwd=tmp_path,
+        check=True,
+        env=_isolated_git_env(),
+    )
     r = _run_script(tmp_path, "0.1.0")
     assert r.returncode != 0
     assert "exist" in r.stderr.lower() or "already" in r.stderr.lower()
@@ -357,13 +370,7 @@ def test_does_not_replace_unrelated_version_when_project_urls_precedes(tmp_path)
         ).strip()
         + "\n"
     )
-    env = {
-        **os.environ,
-        "GIT_AUTHOR_NAME": "test",
-        "GIT_AUTHOR_EMAIL": "test@test",
-        "GIT_COMMITTER_NAME": "test",
-        "GIT_COMMITTER_EMAIL": "test@test",
-    }
+    env = _isolated_git_env()
     for cmd in [
         ["git", "init", "-q", "-b", "main"],
         ["git", "add", "pyproject.toml"],
@@ -404,13 +411,7 @@ def test_does_not_replace_unrelated_version_keys(tmp_path):
         ["git", "commit", "-am", "add tool.foo"],
         cwd=tmp_path,
         check=True,
-        env={
-            **os.environ,
-            "GIT_AUTHOR_NAME": "test",
-            "GIT_AUTHOR_EMAIL": "test@test",
-            "GIT_COMMITTER_NAME": "test",
-            "GIT_COMMITTER_EMAIL": "test@test",
-        },
+        env=_isolated_git_env(),
     )
     r = _run_script(tmp_path, "0.2.0")
     assert r.returncode == 0, f"stderr={r.stderr}"


### PR DESCRIPTION
## Summary

main で post-merge の **E2E P2 proxy test が全 case 失敗** していた bug を修正。

- **Root cause**: [issue #66](https://github.com/ymdarake/agent-zoo/issues/66) で \`bundle/policy.toml\` (単一 file) が \`bundle/policy/*.toml\` (5 profile の directory) に分離されたが、\`bundle/docker-compose.yml\` は \`./policy.toml:/config/policy.toml:ro\` の bind mount のまま → source bundle に policy.toml が無いため Docker が**自動で空ディレクトリを作成** → proxy container の mitmproxy addon が \`open()\` で \`IsADirectoryError\` になっていた。
- **失敗した CI**: https://github.com/ymdarake/agent-zoo/actions/runs/24632014529

## Fix

- \`tests/e2e/test_proxy_block.py::proxy_up\` fixture で \`bundle/policy/all.toml\` (旧 default 相当) を \`bundle/policy.toml\` に一時 copy、teardown で削除
- \`.gitignore\` に \`bundle/policy.toml\` safety net (Ctrl-C 中断時の残留を commit から排除)

本番 flow (\`zoo init --policy <profile>\`) は \`<workspace>/.zoo/policy.toml\` を生成するので影響なし。source bundle で直接 \`docker compose up\` する E2E P2 固有の互換層。

## Bonus: test isolation (\`tests/test_release_prepare_script.py\`)

maintainer が \`~/.gitconfig\` で \`tag.gpgsign = true\` を有効化すると \`test_rejects_existing_tag\` の \`git tag v0.1.0\` が \"fatal: no tag message?\" で fail する fragile 性を修正。\`GIT_CONFIG_GLOBAL=/dev/null\` / \`GIT_CONFIG_SYSTEM=/dev/null\` を subprocess env に追加して maintainer の global config と絶縁。共通 helper \`_isolated_git_env()\` で DRY 化。

CI では gpg config が無いため従来から通るが、SSH commit signing をセットアップした dev env で fail していた。

## Test plan

- [x] Unit: 572 passed (既存 + test isolation helper 化の回帰 0)
- [ ] E2E P2: CI で docker compose daemon 経由で green を確認 (Docker が無い local では skip)
- [x] 本番 flow (\`zoo init\` → \`.zoo/policy.toml\` 参照) に影響無し (fixture は \`tests/e2e/\` 内のみ)

🤖 Generated with [Claude Code](https://claude.com/claude-code)