### PR TITLE
:memo: user-facing 文言から internal ref (ADR / issue / Sprint) を除去

### DIFF
--- a/bundle/dashboard/templates/partials/inbox.html
+++ b/bundle/dashboard/templates/partials/inbox.html
@@ -1,5 +1,5 @@
 <h4>Inbox Requests</h4>
-<p><small>エージェントが提出した未承認のリクエスト（ADR 0001）。許可するとそのまま <code>policy.runtime.toml</code> に反映されます。</small></p>
+<p><small>エージェントが提出した未承認のリクエスト。許可するとそのまま <code>policy.runtime.toml</code> に反映されます。</small></p>
 
 {% if items %}
 {# data-bulk-scope は bulk button と table を同 element で囲み、btn.closest('[data-bulk-scope]')

--- a/bundle/templates/HARNESS_RULES.md
+++ b/bundle/templates/HARNESS_RULES.md
@@ -15,7 +15,7 @@
 ## 制約を超える作業が必要な場合
 
 `/harness/inbox/` ディレクトリに新規 TOML ファイルを作成して
-**Policy Inbox Request** を出してください（ADR 0001）。
+**Policy Inbox Request** を出してください。
 
 ファイル名は同名衝突を避けるため `<日時>-<任意ユニーク文字列>.toml` を推奨します
 （例: `2026-04-18T10-23-45-myreq.toml`）。

--- a/docs/user/policy-reference.md
+++ b/docs/user/policy-reference.md
@@ -180,4 +180,4 @@ min_size = 50000
 
 | 変数 | デフォルト | 説明 |
 |---|---|---|
-| `POLICY_LOCK_DIR` | `/locks` | `policy.runtime.toml` の cross-container shared/exclusive lock ファイルを置くディレクトリ。proxy / dashboard 双方から writable な共有 dir である必要がある (Sprint 006 PR F、TOCTOU M-8 対策)。`zoo init` が `.zoo/locks/` を生成し、docker-compose.yml が `./locks:/locks` を bind mount する。host-mode で proxy を動かす場合は writable な絶対パスを指定（未指定でも policy_path 同階層 → tempdir の順で fallback する）。`<dir>/<basename>.lock` の形式で lock file が作られる。 |
+| `POLICY_LOCK_DIR` | `/locks` | `policy.runtime.toml` の cross-container shared/exclusive lock ファイルを置くディレクトリ。proxy / dashboard 双方から writable な共有 dir である必要がある (TOCTOU 対策)。`zoo init` が `.zoo/locks/` を生成し、docker-compose.yml が `./locks:/locks` を bind mount する。host-mode で proxy を動かす場合は writable な絶対パスを指定（未指定でも policy_path 同階層 → tempdir の順で fallback する）。`<dir>/<basename>.lock` の形式で lock file が作られる。 |

--- a/src/zoo/api.py
+++ b/src/zoo/api.py
@@ -37,7 +37,7 @@ _BUNDLED_DIRS = [
 
 
 class PolicyProfile(str, enum.Enum):
-    """`zoo init --policy <profile>` で選択可能な初期ポリシープロファイル (issue #66).
+    """`zoo init --policy <profile>` で選択可能な初期ポリシープロファイル。
 
     str subclass 化しているのは以下 2 点のため:
     - typer が Enum を native に choice として扱う（`--help` 自動生成 + invalid value exit 2）
@@ -69,7 +69,7 @@ def _coerce_policy_profile(value: PolicyProfile | str) -> PolicyProfile:
 
 
 def _asset_source() -> Path:
-    """Locate bundled assets (ADR 0002 D7).
+    """Locate bundled assets.
 
     - Installed: `zoo/_assets/.zoo/` (= 配布物の `.zoo/` 構造)
     - Source repo (開発時): `bundle/` (source repo root から検索)
@@ -117,12 +117,12 @@ def init(
     force: bool = False,
     policy: PolicyProfile | str = PolicyProfile.minimal,
 ) -> Path:
-    """Bootstrap a ready-to-use agent-zoo workspace at ``target_dir`` (ADR 0002).
+    """Bootstrap a ready-to-use agent-zoo workspace at ``target_dir``.
 
-    新 layout: 全 zoo 管理ファイルを ``target/.zoo/`` 配下に集約。
+    全 zoo 管理ファイルを ``target/.zoo/`` 配下に集約。
     - ``target/.zoo/`` 配下に bundled files / dirs をコピー
     - ``target/.zoo/policy.toml`` は ``policy`` 引数で選択された profile を書き出す
-      (issue #66; default = minimal = secure by default)
+      (default = minimal = secure by default)
     - ``target/.gitignore`` (workspace 用、`.zoo/` 1 行) を配置（既存 skip）
     - ``target/.zoo/.gitignore`` (内部 runtime artifact 除外) を配置
     - runtime dirs (``data/``, ``certs/``, ``inbox/``) と


### PR DESCRIPTION
## Summary

利用者の目に入る 4 箇所から maintainer 向けの内部参照 (ADR 0001 / Sprint 006 PR F / issue #66 等) を削除。0.1.1 stable release 前の文言整理。

## 変更

| 場所 | 内容 |
|---|---|
| \`bundle/dashboard/templates/partials/inbox.html\` | dashboard UI の Inbox 説明文から \`（ADR 0001）\` 削除 |
| \`bundle/templates/HARNESS_RULES.md\` | agent に inject される harness rules から \`（ADR 0001）\` 削除 |
| \`docs/user/policy-reference.md\` | \`POLICY_LOCK_DIR\` 説明を \`(Sprint 006 PR F、TOCTOU M-8 対策)\` → \`(TOCTOU 対策)\` に |
| \`src/zoo/api.py\` | \`help()\` / IDE tooltip で露出する docstring 3 箇所から ADR/issue 番号を削除 |

## scope 外 (保持)

- source comment (rendered HTML に出ない Jinja \`{# ... #}\` / module-level \`# \` コメント / 内部 Python comment)
- dashboard static JS/CSS の deep jargon (\`包括レビュー\` / \`Gemini G\` / \`self-review\`) — browser DevTools で見えるが maintainer の歴史記録として許容

理由: 利用者が通常目にする 4 経路 (UI / agent rules / user docs / Python API help) のみに絞る方針。

## Test

615 unit test all green。UI / docstring 変更のみなので既存 test に影響なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)