### PR TITLE
:sparkles: Dockerfile.base: CA bundle env for pip / Python requests / Node.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`zoo run` / `zoo up` / `zoo task` で Docker image 未 build 時の UX 改善** — 初回起動時 (または `zoo build` を忘れた時) に agent-zoo 系 image が未 build だと compose が registry pull を試みて `pull access denied` で落ちる問題を解決:
   - `docker-compose.yml` の agent service (`claude` / `codex` / `gemini` / `unified`) に `image: agent-zoo-<agent>:latest` + `pull_policy: never` を明示追加。registry pull 試行を抑止
   - `api.run` / `api.task` / `api.bash` / `api.up` の各 entry で `ensure_agent_images_built()` を呼び、`agent-zoo-base:latest` / `agent-zoo-<agent>:latest` の存在を `docker image inspect` で pre-check。無ければ English hint (`Run 'zoo build --agent <agent>' first`) を stderr に出して fail-fast。低レイヤ `runner.compose_up` からは呼ばず、単体 test の purity を保つ設計
+- **Dockerfile.base に CA bundle env 追加 — corporate root CA 配下での `zoo build` を fix** — `certs/extra/` に企業 root CA を配置 + `update-ca-certificates` は system CA store (`/etc/ssl/certs/ca-certificates.crt`) に追加するが、**pip / Python requests / Node.js (npm) はそれぞれ自前 bundle (`certifi` / node built-in) を使う**ため、TLS 検証が fail して build 時の `npm install @anthropic-ai/claude-code` / `pip install` 等がエラーで止まる問題を解決。`Dockerfile.base` の `update-ca-certificates` 直後に `SSL_CERT_FILE` / `REQUESTS_CA_BUNDLE` / `PIP_CERT` / `NODE_EXTRA_CA_CERTS` の 4 つを system bundle path に向ける `ENV` を追加。base image から派生する agent image (claude / codex / gemini / unified) でも継承され、build 時 RUN + runtime の両方で TLS 解決が通る。5 unit test で regression 防止 (env の存在 + `update-ca-certificates` 後の順序 assert)
 
 ## [0.1.1] - 2026-04-20
 

--- a/bundle/container/Dockerfile.base
+++ b/bundle/container/Dockerfile.base
@@ -22,6 +22,18 @@ RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates
     && update-ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
+# update-ca-certificates は system CA store
+# (/etc/ssl/certs/ca-certificates.crt) に extra CA を追加するが、pip /
+# Python requests / Node.js は system store を見ずに自前 bundle (certifi /
+# node built-in) を使うため、corporate CA を含む環境で TLS 検証が fail する。
+# 4 つの env で bundle path を統一し、build 時の RUN (npm install 等) と
+# runtime の両方で TLS 解決が通るようにする。base image からの派生
+# (claude / codex / gemini / unified) でも継承される。
+ENV SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt \
+    REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt \
+    PIP_CERT=/etc/ssl/certs/ca-certificates.crt \
+    NODE_EXTRA_CA_CERTS=/etc/ssl/certs/ca-certificates.crt
+
 RUN apt-get update && apt-get install -y --no-install-recommends \
     git sqlite3 curl wget gnupg \
     python3 python3-pip jq less ripgrep \

--- a/tests/test_dockerfile_ca_envvars.py
+++ b/tests/test_dockerfile_ca_envvars.py
@@ -1,0 +1,86 @@
+"""Tests for Dockerfile.base CA environment variable setup.
+
+`certs/extra/` に企業 root CA 等を置いた場合、`update-ca-certificates` で
+system CA bundle (`/etc/ssl/certs/ca-certificates.crt`) には追加されるが、
+それだけでは以下は TLS 検証 fail する:
+
+- **pip**: デフォルトで `certifi` bundle を使用
+- **Python requests**: 同上
+- **Node.js (npm / agent CLI)**: 自前 CA store を使用、system CA を読まない
+
+これらを同じ system CA bundle に向けるため、Dockerfile.base に 4 つの env
+変数を設定する。base image 由来の全 agent image (claude / codex / gemini /
+unified) + build 時の RUN (npm install 等) の両方で TLS 解決が通る。
+"""
+
+from __future__ import annotations
+
+import pathlib
+
+
+DOCKERFILE_BASE = pathlib.Path("bundle/container/Dockerfile.base")
+
+
+def _dockerfile_text() -> str:
+    return DOCKERFILE_BASE.read_text()
+
+
+# expected value: update-ca-certificates が populate する system bundle path
+# (Debian / Ubuntu 系) — alpine 禁止なので `/etc/ssl/certs/ca-certificates.crt` 固定
+_EXPECTED_BUNDLE = "/etc/ssl/certs/ca-certificates.crt"
+
+
+def test_has_ssl_cert_file_env():
+    """stdlib ssl / openssl 系が読む SSL_CERT_FILE を設定。"""
+    text = _dockerfile_text()
+    assert f"SSL_CERT_FILE={_EXPECTED_BUNDLE}" in text, (
+        "Dockerfile.base に SSL_CERT_FILE 未設定 — stdlib ssl が corporate CA を検証できない"
+    )
+
+
+def test_has_requests_ca_bundle_env():
+    """Python requests が読む REQUESTS_CA_BUNDLE を設定。"""
+    text = _dockerfile_text()
+    assert f"REQUESTS_CA_BUNDLE={_EXPECTED_BUNDLE}" in text, (
+        "Dockerfile.base に REQUESTS_CA_BUNDLE 未設定 — requests が corporate CA を検証できない"
+    )
+
+
+def test_has_pip_cert_env():
+    """pip install 時の TLS 検証用 PIP_CERT を設定 (certifi 依存を迂回)。"""
+    text = _dockerfile_text()
+    assert f"PIP_CERT={_EXPECTED_BUNDLE}" in text, (
+        "Dockerfile.base に PIP_CERT 未設定 — pip install が corporate CA を検証できない"
+    )
+
+
+def test_has_node_extra_ca_certs_env():
+    """Node.js (npm install + agent CLI) 用 NODE_EXTRA_CA_CERTS を設定。"""
+    text = _dockerfile_text()
+    assert f"NODE_EXTRA_CA_CERTS={_EXPECTED_BUNDLE}" in text, (
+        "Dockerfile.base に NODE_EXTRA_CA_CERTS 未設定 — npm install が corporate CA を検証できない"
+    )
+
+
+def test_env_placed_after_update_ca_certificates():
+    """env は `update-ca-certificates` が bundle を populate した後に設定されていること
+    (順序が逆だと build 早期の RUN で bundle 未生成、env が指す path が空)。"""
+    text = _dockerfile_text()
+    lines = text.splitlines()
+
+    # update-ca-certificates を含む行の index
+    ca_update_idx = next(
+        (i for i, ln in enumerate(lines) if "update-ca-certificates" in ln),
+        -1,
+    )
+    assert ca_update_idx >= 0, "update-ca-certificates 呼び出しが無い"
+
+    # SSL_CERT_FILE を含む行の index (代表として 1 つ確認)
+    env_idx = next(
+        (i for i, ln in enumerate(lines) if "SSL_CERT_FILE=" in ln),
+        -1,
+    )
+    assert env_idx > ca_update_idx, (
+        f"SSL_CERT_FILE env (line {env_idx+1}) が "
+        f"update-ca-certificates (line {ca_update_idx+1}) より前に書かれている"
+    )


### PR DESCRIPTION
## 問題

\`certs/extra/\` に企業 root CA を配置して \`zoo build\` すると、\`update-ca-certificates\` は system CA store (\`/etc/ssl/certs/ca-certificates.crt\`) に extra CA を追加するが、以下は**自前 bundle を使う**ので corporate CA を検証できず TLS エラーで build fail する:

- **pip**: \`certifi\` bundle (path: \`certifi.where()\`)
- **Python requests**: 同上
- **Node.js (npm install)**: node 組み込みの root cert list

症状例: build 時 \`npm install @anthropic-ai/claude-code\` 等で \`UNABLE_TO_GET_ISSUER_CERT_LOCALLY\` TLS error。

## 対策

\`Dockerfile.base\` の \`update-ca-certificates\` 直後に、system CA bundle path を各エコシステムの env 変数に向ける:

\`\`\`dockerfile
ENV SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt \\
    REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt \\
    PIP_CERT=/etc/ssl/certs/ca-certificates.crt \\
    NODE_EXTRA_CA_CERTS=/etc/ssl/certs/ca-certificates.crt
\`\`\`

効果:
- base image の build 時 RUN
- 派生 agent image (claude / codex / gemini / unified) の build 時 RUN
- runtime (agent コンテナ内で pip / npm / Python 実行)

全てで corporate CA 込みの TLS 解決が通る。

## Test

\`tests/test_dockerfile_ca_envvars.py\` 5 件:
- 4 env 変数それぞれが Dockerfile.base に存在すること
- env が \`update-ca-certificates\` より後ろに書かれていること (順序逆だと build 早期の RUN で bundle 未生成 state で env 貼付、silent に壊れる)

**合計 620 unit test all green**。

## 関連

- PR #80 (\`fix/zoo-run-image-precheck\`): 同じく build 周辺 UX 改善系だが独立 scope
- issue #64 (zoo certs import): \`.zoo/certs/extra/\` に CA cert を入れる CLI

🤖 Generated with [Claude Code](https://claude.com/claude-code)