### PR TITLE
:bug: dashboard: PEP 668 回避 (base に python3-venv + dashboard 内で venv)

### DIFF
--- a/bundle/container/Dockerfile.base
+++ b/bundle/container/Dockerfile.base
@@ -36,7 +36,7 @@ ENV SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt \
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     git sqlite3 curl wget gnupg \
-    python3 python3-pip jq less ripgrep \
+    python3 python3-pip python3-venv jq less ripgrep \
     && rm -rf /var/lib/apt/lists/*
 
 # B-2 (cont.): GitHub CLI (gh) を公式 apt repo から install (#19)

--- a/bundle/dashboard/Dockerfile
+++ b/bundle/dashboard/Dockerfile
@@ -2,9 +2,15 @@
 # base 側が `certs/extra/` COPY + `update-ca-certificates` + 4 つの CA env
 # (SSL_CERT_FILE / REQUESTS_CA_BUNDLE / PIP_CERT / NODE_EXTRA_CA_CERTS) を
 # 済ませているので、dashboard 側で corporate root CA 対応を重複実装する必要なし。
-# base は node:20-slim 派生 + apt で python3 / python3-pip を含むため、ここで
-# pip install / gunicorn が動く。
+# base は node:20-slim 派生 + apt で python3 / python3-pip / python3-venv を含む。
 FROM agent-zoo-base:latest
+
+# Debian 系 system python は PEP 668 で `EXTERNALLY-MANAGED` マーク付き、
+# system への `pip install` が block されるため dashboard 専用 virtualenv を
+# /opt/venv に作る。PATH 先頭に venv bin を置き、以降の pip / python /
+# gunicorn はこの venv 実行形を使う。
+RUN python3 -m venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
 
 WORKDIR /app
 


### PR DESCRIPTION
## 症状

v0.1.3 で dashboard を \`FROM agent-zoo-base:latest\` に切替え後、\`zoo build\` の dashboard image layer で:

\`\`\`
error: externally-managed-environment

× This environment is externally managed
╰─> This Python installation is managed by the operating system...
    To install Python packages system-wide, try apt install python3-xyz,
    where xyz is the package you are trying to install.
\`\`\`

## 原因

agent-zoo-base = \`node:20-slim\` + \`apt install python3 python3-pip\`。Debian 系 system python は PEP 668 で \`/usr/lib/python3.X/EXTERNALLY-MANAGED\` マーク付き、system への直接 \`pip install\` は block される。

v0.1.3 以前の \`FROM python:3.12-slim\` は公式 Python image でこのマーク無しだったので通っていた。

## 修正 (3 行)

- \`bundle/container/Dockerfile.base\`: apt に \`python3-venv\` 追加
- \`bundle/dashboard/Dockerfile\`: \`python3 -m venv /opt/venv\` + \`PATH=/opt/venv/bin:$PATH\`

dashboard 専用 venv に pip install し、system python を汚さない (PEP 668 の意図通り)。

## 検証

user が corporate CA 配下 workspace で手動パッチ当てて \`zoo build --no-cache\` が完走することを確認済。本 PR はそのパッチを source repo に反映。

既存 630 unit test all green。

## 関連

- v0.1.3 (#85, merged): dashboard を agent-zoo-base 継承に切替え (今回 fix 対象の変更)
- v0.1.4 でこの fix を出す

🤖 Generated with [Claude Code](https://claude.com/claude-code)