### PR TITLE
:bug: certs: bundle.pem を自動 aggregate (mitmproxy 上流 TLS 検証の単一 file 要求に対応)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **`zoo certs import` が `certs/extra/bundle.pem` を自動生成しない設計欠陥** — mitmproxy は上流 TLS 検証に `--set ssl_verify_upstream_trusted_ca=/certs/extra/bundle.pem` で単一 file path を要求するが、`certs_import` / `certs_remove` / `init` は個別 PEM file 操作のみで bundle への aggregate を行っておらず、user が手動で `cat *.pem > bundle.pem` しない限り自社サーバー (corporate private CA) への TLS handshake で cert chain 検証 fail していた。
+  - `_rebuild_cert_bundle()` を新設、`certs/extra/` 内の全 user PEM (`.gitkeep` と `bundle.pem` 自身を除く) を結合して `bundle.pem` を自動再生成
+  - `certs_import` / `certs_remove` の最後 + `init` (古い version で import 済 workspace への遡及適用) で呼ぶ
+  - `bundle.pem` は予約名、`zoo certs import --name bundle.pem` / `zoo certs remove bundle.pem` は明示 error で reject
+  - `zoo certs list` は `bundle.pem` を自動生成物として除外
+  - CLI hint に "mitmproxy 稼働中なら `zoo down && zoo up` で再読込" 案内追加
+  - 7 unit test (import / remove / list / 予約名 / init 遡及)
+
 ## [0.1.4] - 2026-04-20
 
 v0.1.3 で dashboard を `FROM agent-zoo-base:latest` に切替えた副作用として、base の system python (Debian 系 `node:20-slim` + apt python3) が PEP 668 で externally-managed となり、dashboard の `pip install` が `externally-managed-environment` エラーで fail する問題を修正。

--- a/src/zoo/api.py
+++ b/src/zoo/api.py
@@ -193,6 +193,9 @@ def init(
     extra_gitkeep = zoo_target / "certs" / "extra" / ".gitkeep"
     if not extra_gitkeep.exists():
         extra_gitkeep.touch()
+    # 古い version で import 済の extra/*.pem がある workspace を再 init する
+    # 場合に bundle.pem を同期生成する (mitmproxy 上流 TLS 検証用)
+    _rebuild_cert_bundle(zoo_target / "certs" / "extra")
     (zoo_target / "policy.runtime.toml").touch(exist_ok=True)
 
     return target
@@ -356,6 +359,11 @@ def certs() -> None:
 # --- certs import / list / remove (issue #64) -------------------------------
 
 _CERT_NAME_PROTECTED = (".gitkeep",)  # 完全一致のみ (`.gitkeep.pem` 等は拡張子 whitelist で別途遮断)
+
+# mitmproxy の `--set ssl_verify_upstream_trusted_ca` に渡す bundle file。
+# zoo certs import / remove / init で自動再生成される aggregated file なので
+# user 操作 (import --name bundle.pem 等) からは予約する。
+_CERT_BUNDLE_NAME = "bundle.pem"
 _CERT_EXTENSIONS = (".pem", ".crt", ".cer")
 _PEM_HEADER = b"-----BEGIN CERTIFICATE-----"
 
@@ -368,6 +376,11 @@ def _check_cert_name_path_safety(name: str) -> None:
         raise ValueError(f"reserved name: {name!r}")
     if any(c in name for c in ("/", "\\", "\x00")):
         raise ValueError(f"name contains path separator or NUL: {name!r}")
+    if name == _CERT_BUNDLE_NAME:
+        raise ValueError(
+            f"name {name!r} is reserved for the auto-aggregated bundle; "
+            "rename your cert file to something else"
+        )
     if name in _CERT_NAME_PROTECTED:
         raise ValueError(f"{name} is protected")
 
@@ -382,6 +395,32 @@ def _validate_cert_name(name: str) -> str:
             f"name must end with .pem / .crt / .cer: {name!r}"
         )
     return name
+
+
+def _rebuild_cert_bundle(extra: Path) -> None:
+    """`<extra>/bundle.pem` を extra/ 内の全 user cert を結合して再生成する。
+
+    mitmproxy は上流 TLS 検証に ``--set ssl_verify_upstream_trusted_ca=<path>`` で
+    **単一 file** を要求するため、個別 `.pem` file を aggregate した bundle を
+    自動維持する必要がある。`certs_import` / `certs_remove` / `init` から呼ぶ。
+
+    - 結合対象: extra/ 内の通常 file のうち、`_CERT_NAME_PROTECTED` (= `.gitkeep`)
+      と bundle file 自身を除く
+    - 結合内容: 各 PEM の bytes を `\\n` で join
+    - extra/ に結合対象が 1 つも無ければ bundle を削除 (空 bundle を残さず、
+      docker-compose.yml が `[ -f bundle.pem ]` 判定で条件分岐できる)
+    """
+    bundle = extra / _CERT_BUNDLE_NAME
+    pems = sorted(
+        p for p in extra.iterdir()
+        if p.is_file()
+        and p.name not in _CERT_NAME_PROTECTED
+        and p.name != _CERT_BUNDLE_NAME
+    )
+    if not pems:
+        bundle.unlink(missing_ok=True)
+        return
+    bundle.write_bytes(b"\n".join(p.read_bytes() for p in pems))
 
 
 def _extra_certs_dir() -> Path:
@@ -462,15 +501,19 @@ def certs_import(
     # CA cert は public 情報のため shutil.copy2 が source mode を継承する挙動を許容。
     # follow_symlinks=True で symlink target の通常 file をコピー (= dest は symlink にならない)。
     shutil.copy2(resolved, dest, follow_symlinks=True)
+    # mitmproxy が上流 TLS 検証に使う bundle を再生成 (単一 path 要求への対応)
+    _rebuild_cert_bundle(extra)
     return dest
 
 
 def certs_list() -> list[str]:
-    """`extra/` 配下の cert ファイル名を sorted で返す (`.gitkeep` 除外)。"""
+    """`extra/` 配下の cert ファイル名を sorted で返す (`.gitkeep` / bundle.pem 除外)。"""
     extra = _extra_certs_dir()
     return sorted(
         p.name for p in extra.iterdir()
-        if p.is_file() and p.name not in _CERT_NAME_PROTECTED
+        if p.is_file()
+        and p.name not in _CERT_NAME_PROTECTED
+        and p.name != _CERT_BUNDLE_NAME
     )
 
 
@@ -481,11 +524,18 @@ def certs_remove(name: str) -> bool:
     Raises: ValueError (`.gitkeep` 試行 / path traversal)
     """
     _check_cert_name_path_safety(name)
+    if name == _CERT_BUNDLE_NAME:
+        raise ValueError(
+            f"{name!r} is the auto-aggregated bundle; remove individual "
+            "cert files instead (bundle is regenerated automatically)"
+        )
     extra = _extra_certs_dir()
     target = extra / name
     if not target.is_file():
         return False
     target.unlink()
+    # 削除反映 (残 cert から bundle 再生成、空なら bundle も削除)
+    _rebuild_cert_bundle(extra)
     return True
 
 

--- a/src/zoo/cli.py
+++ b/src/zoo/cli.py
@@ -148,8 +148,11 @@ def certs_import_cmd(
         raise SystemExit(str(e))
     typer.echo(f"Imported: {dest}")
     typer.secho(
-        "Note: extra cert を image に反映するには `zoo build --no-cache` が必要です。\n"
-        "      (--no-cache 無しだと Docker layer cache hit で COPY 再評価されません)",
+        "Note:\n"
+        "  - extra cert を image に反映するには `zoo build --no-cache` が必要です。\n"
+        "    (--no-cache 無しだと Docker layer cache hit で COPY 再評価されません)\n"
+        "  - mitmproxy 上流 TLS 検証用の bundle.pem を自動再生成しました。\n"
+        "    mitmproxy 稼働中の場合は `zoo down && zoo up` で再読込してください。",
         fg=typer.colors.YELLOW,
     )
 

--- a/tests/test_certs_bundle_autoaggregate.py
+++ b/tests/test_certs_bundle_autoaggregate.py
@@ -1,0 +1,132 @@
+"""Tests for automatic `certs/extra/bundle.pem` aggregation.
+
+mitmproxy は上流 TLS 検証に ``--set ssl_verify_upstream_trusted_ca`` で
+**単一 path** (`bundle.pem`) を要求する。`zoo certs import` / `certs_remove`
+で個別 PEM file を操作した時、bundle.pem を自動再生成する仕組みがないと
+user が手動で `cat *.pem > bundle.pem` しなければならない (設計欠陥)。
+
+本 module は以下を検証:
+
+- `certs_import` 後に ``bundle.pem`` が extra/ 内の全 PEM を結合した内容で生成
+- `certs_remove` 後に bundle.pem が更新 (削除した cert の内容が消える)
+- 全 cert が remove された時、bundle.pem も削除 (empty bundle を残さない)
+- bundle.pem 自体は import 対象外 (再帰結合しない)
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import pytest
+
+import zoo
+from zoo import api, runner
+
+
+_PEM_A = b"""-----BEGIN CERTIFICATE-----
+MIIAAAAA-FAKE-CERT-A-FOR-TEST-ONLY
+-----END CERTIFICATE-----
+"""
+
+_PEM_B = b"""-----BEGIN CERTIFICATE-----
+MIIBBBBB-FAKE-CERT-B-FOR-TEST-ONLY
+-----END CERTIFICATE-----
+"""
+
+
+@pytest.fixture
+def workspace(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """tmp_path に `.zoo/certs/extra/` を用意し CWD を合わせる。"""
+    zoo_dir = tmp_path / ".zoo"
+    (zoo_dir / "certs" / "extra").mkdir(parents=True)
+    (zoo_dir / "docker-compose.yml").write_text("")
+    (zoo_dir / "certs" / "extra" / ".gitkeep").touch()
+    monkeypatch.chdir(tmp_path)
+    runner.workspace_root.cache_clear()
+    runner.zoo_dir.cache_clear()
+    yield tmp_path
+    runner.workspace_root.cache_clear()
+    runner.zoo_dir.cache_clear()
+
+
+def _write_src_pem(tmp_path: Path, name: str, body: bytes) -> Path:
+    src = tmp_path / name
+    src.write_bytes(body)
+    return src
+
+
+def test_import_creates_bundle_pem(workspace: Path, tmp_path: Path) -> None:
+    src = _write_src_pem(tmp_path, "corp.pem", _PEM_A)
+    api.certs_import(src)
+    bundle = workspace / ".zoo" / "certs" / "extra" / "bundle.pem"
+    assert bundle.exists(), "bundle.pem が生成されていない"
+    assert _PEM_A in bundle.read_bytes()
+
+
+def test_import_multiple_aggregates_all(workspace: Path, tmp_path: Path) -> None:
+    api.certs_import(_write_src_pem(tmp_path, "corp.pem", _PEM_A))
+    api.certs_import(_write_src_pem(tmp_path, "internal.pem", _PEM_B))
+    bundle = workspace / ".zoo" / "certs" / "extra" / "bundle.pem"
+    content = bundle.read_bytes()
+    assert _PEM_A in content
+    assert _PEM_B in content
+
+
+def test_remove_updates_bundle(workspace: Path, tmp_path: Path) -> None:
+    api.certs_import(_write_src_pem(tmp_path, "corp.pem", _PEM_A))
+    api.certs_import(_write_src_pem(tmp_path, "internal.pem", _PEM_B))
+    api.certs_remove("corp.pem")
+    bundle = workspace / ".zoo" / "certs" / "extra" / "bundle.pem"
+    content = bundle.read_bytes()
+    assert _PEM_A not in content, "削除した cert が bundle から消えていない"
+    assert _PEM_B in content
+
+
+def test_remove_last_cert_deletes_bundle(workspace: Path, tmp_path: Path) -> None:
+    api.certs_import(_write_src_pem(tmp_path, "corp.pem", _PEM_A))
+    api.certs_remove("corp.pem")
+    bundle = workspace / ".zoo" / "certs" / "extra" / "bundle.pem"
+    assert not bundle.exists(), (
+        "extra/*.pem が空なのに bundle.pem が残留 (mitmproxy が空 bundle を誤読)"
+    )
+
+
+def test_bundle_pem_itself_is_not_listed_in_certs_list(
+    workspace: Path, tmp_path: Path
+) -> None:
+    """`zoo certs list` は bundle.pem を自動生成物として除外する。"""
+    api.certs_import(_write_src_pem(tmp_path, "corp.pem", _PEM_A))
+    assert "bundle.pem" not in api.certs_list()
+
+
+def test_bundle_pem_is_rejected_as_import_source_name(
+    workspace: Path, tmp_path: Path
+) -> None:
+    """`zoo certs import foo.pem --name bundle.pem` は reject (予約名)。"""
+    src = _write_src_pem(tmp_path, "corp.pem", _PEM_A)
+    with pytest.raises(ValueError, match=r"bundle\.pem"):
+        api.certs_import(src, name="bundle.pem")
+
+
+def test_init_rebuilds_bundle_from_existing_extras(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """既存 extra/*.pem がある workspace で zoo init を再実行すると bundle を再生成。
+    (古い version で import した user が `zoo init --force` でも `init` でも同期可能)。"""
+    target = tmp_path / "ws"
+    target.mkdir()
+    runner.workspace_root.cache_clear()
+    runner.zoo_dir.cache_clear()
+    # zoo init で .zoo/ 展開
+    api.init(target_dir=target)
+    extra = target / ".zoo" / "certs" / "extra"
+    # 既存の extra/ に pem を直接配置 (古い import 経由を simulate)
+    (extra / "corp.pem").write_bytes(_PEM_A)
+    # bundle は無い状態で再度 init
+    assert not (extra / "bundle.pem").exists()
+    api.init(target_dir=target)
+    assert (extra / "bundle.pem").exists(), (
+        "既存 extra/*.pem がある時に zoo init が bundle を再生成していない"
+    )
+    assert _PEM_A in (extra / "bundle.pem").read_bytes()


### PR DESCRIPTION
## 症状

user が \`zoo certs import corp.pem\` で自社 CA を配置 + policy 許可リスト追加しても、agent container から自社サーバーへの TLS handshake で cert chain 検証 fail。

## 原因

mitmproxy は上流 TLS 検証に **単一 file path** \`/certs/extra/bundle.pem\` を要求 (docker-compose.yml の proxy command 参照)。しかし \`certs_import\` / \`certs_remove\` は個別 file を操作するだけで **bundle 自動生成を一切していない設計欠陥**。user が手動で \`cat *.pem > bundle.pem\` しないと新 cert が反映されない。

## 修正

- \`_rebuild_cert_bundle()\` 新設: \`certs/extra/\` の全 PEM を結合して \`bundle.pem\` 自動再生成 (空になったら削除)
- \`certs_import\` / \`certs_remove\` / \`init\` (古い workspace への遡及適用) で呼ぶ
- \`bundle.pem\` を予約名化 (import --name / remove 対象から除外)
- \`certs_list()\` は bundle を自動生成物として listing 除外
- CLI hint に \`zoo down && zoo up\` 再読込案内追加

## Test

7 新規 unit test (tmp workspace で実挙動検証):
- import で bundle 生成、複数 import で aggregate
- remove で bundle 更新、最後の cert 削除で bundle 消滅
- 予約名 \`bundle.pem\` 拒否
- \`certs_list\` に bundle 含まれない
- 古い extra/*.pem を持つ workspace で \`zoo init\` が bundle 遡及生成

既存 630 + 新 7 = **637 unit test all green**。

## 関連

v0.1.2 (#81) で \`certs/extra/\` を build 時に system CA store に追加する env を入れたが、mitmproxy の runtime 上流 TLS 検証は別レイヤで bundle 形式を要求することを見逃していた。本 PR で 2 レイヤ (build 時 system CA / runtime mitmproxy bundle) 両対応が完結。

🤖 Generated with [Claude Code](https://claude.com/claude-code)